### PR TITLE
[fix/#41] 채팅화면에서 하단 탭 노출 수정

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,16 +1,16 @@
-import { Tabs } from 'expo-router';
-import React, { useEffect, useRef, useState } from 'react';
-import { Image, Text, AppState, AppStateStatus, Dimensions, Alert } from 'react-native';
-import messaging from '@react-native-firebase/messaging';
-import * as Notifications from 'expo-notifications';
+import queryClient from '@/api/queryClient';
+import NotificationPermissionModal from '@/components/NotificationPermissionModal';
 import {
-  postFcmDeviceToken,
   getNotificationsSettingStatus,
   initNotificationsSettingStatus,
+  postFcmDeviceToken,
   putOSPushAgreement,
 } from '@/src/features/notification/api/notifications';
-import NotificationPermissionModal from '@/components/NotificationPermissionModal';
-import queryClient from '@/api/queryClient';
+import messaging from '@react-native-firebase/messaging';
+import * as Notifications from 'expo-notifications';
+import { Tabs, usePathname } from 'expo-router';
+import React, { useEffect, useRef, useState } from 'react';
+import { Alert, AppState, AppStateStatus, Dimensions, Image, Text } from 'react-native';
 
 const { height: screenHeight } = Dimensions.get('window');
 const TAB_BAR_HEIGHT = screenHeight * 0.117; // 화면 높이의 15%
@@ -18,6 +18,10 @@ const TAB_BAR_HEIGHT = screenHeight * 0.117; // 화면 높이의 15%
 export default function TabLayout() {
   const appState = useRef<AppStateStatus>(AppState.currentState);
   const [isNotificationPermissionModalOpen, setIsNotificationPermissionModalOpen] = useState(false);
+  const pathname = usePathname();
+
+  // 채팅방 스크린들에서는 탭 바를 숨김
+  const shouldHideTabBar = pathname.includes('/CreateSpaceScreen') || pathname.includes('/ChattingRoomScreen');
 
   /* 1. FCM 토큰 등록 */
   const updateFcmToken = async () => {
@@ -99,7 +103,7 @@ export default function TabLayout() {
       <Tabs
         screenOptions={{
           headerShown: false,
-          tabBarStyle: {
+          tabBarStyle: shouldHideTabBar ? { display: 'none' } : {
             backgroundColor: '#1D1E1F', // 원하는 배경색
             borderTopWidth: 1,
             borderColor: '#353637',


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

```typescript
// 채팅방 스크린들에서는 탭 바를 숨김
  const shouldHideTabBar = pathname.includes('/CreateSpaceScreen') || pathname.includes('/ChattingRoomScreen');

...

      <Tabs
        screenOptions={{
          headerShown: false,
          tabBarStyle: shouldHideTabBar ? { display: 'none' } : {
            backgroundColor: '#1D1E1F', // 원하는 배경색
            borderTopWidth: 1,
            borderColor: '#353637',
            height: TAB_BAR_HEIGHT,
            paddingTop: 10,
          },
        }}
```

## 🔍 작업 상세 내용

-   채팅 화면에서 하단 탭이 안뜨도록 명시했습니다.

#### iOS에서는 React Navigation이 네이티브 iOS 앱처럼 동작하도록 자동으로 탭 바를 숨기지만, Android에서는 개발자가 명시적으로 설정해야 합니다.


## 🏞️ 스크린샷

#### 변경 전
<img width="258" height="424" alt="image" src="https://github.com/user-attachments/assets/47c56eab-2c5c-4178-870b-307e71a26fdf" />

#### 변경 후
<img width="258" height="424" alt="image" src="https://github.com/user-attachments/assets/1d29b91a-440b-46b7-8112-1e1f0f448011" />



## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #41 
