### PR TITLE
[fix/#43] 채팅방 입장 시 500 error

### DIFF
--- a/app/(tabs)/chat/ChattingRoomScreen.tsx
+++ b/app/(tabs)/chat/ChattingRoomScreen.tsx
@@ -1,20 +1,17 @@
-import React, { useState, useRef, useEffect } from 'react';
-import styled from 'styled-components/native';
+import api from '@/api/axiosInstance';
+import ProfileModal from '@/components/ProfileModal';
+import { Config } from '@/src/lib/config';
+import { formatDate, formatTime } from '@/src/utils/dateUtils';
+import AntDesign from '@expo/vector-icons/AntDesign';
 import Feather from '@expo/vector-icons/Feather';
 import SimpleLineIcons from '@expo/vector-icons/SimpleLineIcons';
-import { useRouter } from 'expo-router';
-import { StatusBar, FlatList, KeyboardAvoidingView, Platform, Alert, TouchableOpacity } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
 import { Client } from '@stomp/stompjs';
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
-import api from '@/api/axiosInstance';
+import React, { useEffect, useRef, useState } from 'react';
+import { Alert, Dimensions, FlatList, Image, InteractionManager, KeyboardAvoidingView, Platform, StatusBar, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Dimensions, Image, InteractionManager } from 'react-native';
-import AntDesign from '@expo/vector-icons/AntDesign';
-import { Config } from '@/src/lib/config';
-import { useNavigation } from 'expo-router';
-import { formatDate, formatTime } from '@/src/utils/dateUtils';
-import ProfileModal from '@/components/ProfileModal';
+import styled from 'styled-components/native';
 
 type ChatHistory = {
   id: number;
@@ -264,7 +261,7 @@ const ChattingRoomScreen = () => {
 
     try {
       const lastMessageId = messages[messages.length - 1]?.id;
-      const res = await api.get(`/api/v1/chat/rooms/${roomId}/messages?lastMessageId=${lastMessageId}`);
+      const res = await api.get(`/api/v1/chat/rooms/${roomId}/messages?lastMessageId=${lastMessageId ? lastMessageId : ''}`);
 
       const olderMessages: ChatHistory[] = res.data.data;
 
@@ -638,7 +635,7 @@ const ChattingRoomScreen = () => {
                             <OtherFirstTextBox>
                               {isSearching ? (
                                 searchMessages[pointerRef.current] &&
-                                searchMessages[pointerRef.current].id === item.id ? (
+                                  searchMessages[pointerRef.current].id === item.id ? (
                                   <HighlightOtherText
                                     text={isTranslate ? item.targetContent : item.content || item.originContent}
                                     keyword={searchText}
@@ -673,7 +670,7 @@ const ChattingRoomScreen = () => {
                             <OtherNotFirstTextBox>
                               {isSearching ? (
                                 searchMessages[pointerRef.current] &&
-                                searchMessages[pointerRef.current].id === item.id ? (
+                                  searchMessages[pointerRef.current].id === item.id ? (
                                   <HighlightOtherText
                                     text={isTranslate ? item.targetContent : item.content || item.originContent}
                                     keyword={searchText}

--- a/app/(tabs)/chat/ChattingRoomScreen.tsx
+++ b/app/(tabs)/chat/ChattingRoomScreen.tsx
@@ -254,6 +254,7 @@ const ChattingRoomScreen = () => {
   };
 
   // 무한 스크롤
+  // TODO: 호출 시점 조정 필요
   const fetchMoreHistory = async () => {
     if (!hasMore) return;
 


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   채팅방 입장 시마다 이전 메시지 불러오기 실패 [AxiosError: Request failed with status code 500] 에러 fix

## 🔍 작업 상세 내용

- lastMessageId가 undefined로 나가고 있는 걸 확인
- 삼항연산자를 적용해서 lastMessageId가 없을 경우 빈 문자열로 설정

```typescript
//기존
const res = await api.get(`/api/v1/chat/rooms/${roomId}/messages?lastMessageId=${lastMessageId}`);

//수정
const res = await api.get(`/api/v1/chat/rooms/${roomId}/messages?lastMessageId=${lastMessageId ? lastMessageId : ''}`);
```

#### DX를 위한 임시방편입니다. 해당 매서드는 무한 스크롤에 사용될 매서드(api)로 채팅방 입장시 호출되어서는 안되는데 log를 보면 'read-all' api 호출 이후 바로 실행되고 있어서 'messages' 변수 할당 이전에 호출되다 보니 undefined 에러가 발생합니다. 호출 시점의 조정이 필요합니다.(ChattingRoomScreen.tsx에 TODO 주석 추가)


## 🏞️ 스크린샷

-   스크린샷이 있다면 첨부해주세요.

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #43 
