### PR TITLE
[hotfix/#88] 회원가입 약관 및 정책 페이지 이동 시 바텀시트 버그

### DIFF
--- a/app/screens/login/CreateAccountScreen.tsx
+++ b/app/screens/login/CreateAccountScreen.tsx
@@ -7,12 +7,13 @@ import { theme } from '@/src/styles/theme';
 import Entypo from '@expo/vector-icons/Entypo';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import axios from 'axios';
-import { useRouter } from 'expo-router';
+import { usePathname, useRouter } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
 import React, { useEffect, useState } from 'react';
 import { Alert, Modal, StatusBar, TouchableOpacity } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import styled from 'styled-components/native';
+import * as Location from 'expo-location';
 
 enum isDuplicatedEmail {
   Init = 'Init',
@@ -42,6 +43,8 @@ const CreateAccountScreen = () => {
   const [check2, setCheck2] = useState(false);
   const [check3, setCheck3] = useState(false);
   const [userLocation, setUserLocation] = useState<Location.LocationObject | null>(null);
+  const pathname = usePathname();
+  const [isNextButtonClicked, setIsNextButtonClicked] = useState<boolean>(false);
 
   const [checks, setChecks] = useState({
     isnull: true,
@@ -150,10 +153,10 @@ const CreateAccountScreen = () => {
         return;
       }
 
-      const { accessToken, refreshToken, userId} = response.data;
+      const { accessToken, refreshToken, userId } = response.data;
       await SecureStore.setItemAsync(ACCESS_KEY, accessToken);
       await SecureStore.setItemAsync(REFRESH_KEY, refreshToken);
-      await SecureStore.setItemAsync("MyuserId",userId.toString());
+      await SecureStore.setItemAsync('MyuserId', userId.toString());
 
       await patchLocation(latitude, longitude);
       router.replace('./SignUpDoneScreen');
@@ -164,16 +167,27 @@ const CreateAccountScreen = () => {
   };
 
   const showModal = () => {
+    setIsNextButtonClicked(true); // 버튼 클릭 여부 저장
     setModalVisible(true); // Next 버튼 클릭 시 모달 열기
   };
 
   const showTermsAndConditions = () => {
+    setModalVisible(false);
     router.push('./TermsAndConditionsScreen');
   };
 
   const showPrivacyPolicy = () => {
+    setModalVisible(false);
     router.push('./PrivacyPolicyScreen');
   };
+
+  // next 버튼 클릭 상태에 따라 모달 열기
+  useEffect(() => {
+    // 회원가입 페이지가 아닌 경우 모달 닫음
+    if (pathname !== '/screens/login/CreateAccountScreen') return;
+
+    if (isNextButtonClicked) setModalVisible(true);
+  }, [pathname]);
 
   return (
     <SafeArea>
@@ -182,7 +196,7 @@ const CreateAccountScreen = () => {
         <HeaderContainer>
           <HeaderBox>
             <TouchableOpacity onPress={() => router.back()}>
-              <Icon type="search" size={24} color={theme.colors.primary.white} />
+              <Icon type="previous" size={24} color={theme.colors.primary.white} />
             </TouchableOpacity>
             <HeaderTitleText>Create your account</HeaderTitleText>
           </HeaderBox>
@@ -426,8 +440,14 @@ const CreateAccountScreen = () => {
         </NextButtonContainer>
       </Container>
       <Modal visible={modalVisible} transparent animationType="slide" onRequestClose={() => setModalVisible(false)}>
-        <ModalOverlay activeOpacity={1}>
-          <BottomSheetContent>
+        <ModalOverlay
+          activeOpacity={1}
+          onPress={() => {
+            setModalVisible(false);
+            setIsNextButtonClicked(false);
+          }}
+        >
+          <BottomSheetContent onStartShouldSetResponder={() => true}>
             <BottomSheetHeader>
               <BottomSheetHandle />
             </BottomSheetHeader>


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

회원가입 페이지 내 약관 동의 바텀시트에서 약관 상세 페이지, 정책 상세 페이지로 이동 시
바텀시트가 사라지지 않고 계속 노출되는 문제를 해결했습니다.

## 🔍 작업 상세 내용

router.push를 통해 동일한 라우트 스택 내의 페이지로 이동할 경우, 이전 페이지의 state는 초기화되지 않고 background에 저장됩니다.
특히 모달의 경우 네비게이션 상태와 독립적으로 렌더링되기 때문에, modalVisible이 false로 초기화되지 않아 계속 모달이 노출되었던 것 같습니다.

따라서 약관 페이지 및 정책 페이지로 이동 시 modalVisible을 false로 변경하는 코드를 추가했습니다.

```typescript
  const showTermsAndConditions = () => {
    setModalVisible(false); // 모달을 끈 후 이동
    router.push('./TermsAndConditionsScreen');
  };
```

그리고 회원가입 페이지로 다시 돌아왔을 때 모달이 다시 켜지도록 하기 위해
회원가입 페이지에서 next button의 클릭 상태를 `isNextButtonClicked`에 저장하고,
현재 페이지가 회원가입 페이지이고 `isNextButtonClicked`이 true일 때 modalVisible을 true로 변경하도록 useEffect를 추가했습니다.

```typescript
  // next 버튼 클릭 상태에 따라 모달 열기
  useEffect(() => {
    // 회원가입 페이지가 아닌 경우 모달 닫음
    if (pathname !== '/screens/login/CreateAccountScreen') return;

    if (isNextButtonClicked) setModalVisible(true);
  }, [pathname]);
```

위 코드들을 추가해 **약관 페이지 및 정책 페이지로 이동할 때 모달이 꺼지고**,
**다시 회원가입 페이지로 돌아왔을 때 모달이 켜지도록** 수정했습니다.

approve 전에 안드로이드 환경에서도 잘 작동하는지 확인 한번만 부탁드립니다!

_(pathname에 라우터를 하드코딩해 현재 페이지가 회원가입 페이지인지 확인하기 때문에 추후 리팩토링이 필요할 것 같습니다.)_

## 🏞️ 스크린샷

-   X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #88 