### PR TITLE
[hotfix/#91] iOS 채팅방 내 키보드 이격 해결

### DIFF
--- a/app/(tabs)/chat/ChattingRoomScreen.tsx
+++ b/app/(tabs)/chat/ChattingRoomScreen.tsx
@@ -564,7 +564,7 @@ const ChattingRoomScreen = () => {
 
   return (
     <SafeArea>
-      {/* <StatusBar barStyle="light-content" /> */}
+      <StatusBar barStyle="light-content" />
       <Container>
         {/* 헤더 */}
         <HeaderContainer>
@@ -862,7 +862,6 @@ export default ChattingRoomScreen;
 // ===================== styled-components =====================
 const SafeArea = styled.SafeAreaView`
   flex: 1;
-  height: 100%;
   background-color: #1d1e1f;
 `;
 const Container = styled.View`


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

iOS 기기로 채팅방 페이지에서 채팅 입력 시 키보드와 채팅 입력 input 사이 공간이 생기는 문제를 해결했습니다.

## 🔍 작업 상세 내용

ChattingRoomScreen 내 `KeyboardAvoidingView`의 속성을 수정했습니다.

기존에는 KeyboardAvoidingView에서 키보드가 올라올 경우, iOS 노치 및 인디케이터 등의 영역만큼의 보정값으로 적용되는 `keyboardVerticalOffset`에 +50이 하드코딩 되어 있었습니다.

따라서 더해져 있던 값을 제거하고, android인 경우 OS에서 자체적으로 높이를 계산해 재적용하기 때문에 해당 값에 0을 적용했습니다.

안드로이드에서도 키보드 UI에 문제 없는지 확인 부탁드립니다.

## 🏞️ 스크린샷

<img width="300" height="1278" alt="스크린샷, 2025-11-04 오전 2 17 02" src="https://github.com/user-attachments/assets/eaa8d2a2-e8c3-4df4-9fad-a784df8a348a" />


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #91
