### PR TITLE
[hotfix/#110] 게시글 클릭 시 앱 강제종료(v1.2.1)

### DIFF
--- a/app/(tabs)/community/[id].tsx
+++ b/app/(tabs)/community/[id].tsx
@@ -3,6 +3,7 @@ import { addBookmark, removeBookmark } from '@/api/community/bookmarks';
 import { blockComment } from '@/api/community/comments';
 import CommentItem, { Comment } from '@/components/CommentItem';
 import Icon from '@/components/common/Icon';
+import ProfileImage from '@/components/common/ProfileImage';
 import ProfileModal from '@/components/ProfileModal';
 import SortTabs, { SortKey } from '@/components/SortTabs';
 import { useCreateComment } from '@/hooks/mutations/useCreateComment';

--- a/app/(tabs)/community/index.tsx
+++ b/app/(tabs)/community/index.tsx
@@ -32,7 +32,7 @@ const pickNonEmpty = (...vals: any[]) => {
 
 const ICON = require('@/assets/images/IsolationMode.png');
 const VisitorImage = require('@/assets/images/character_05.svg');
-const AnonymityImage= require('@/assets/images/character_04.svg');
+const AnonymityImage = require('@/assets/images/character_04.svg');
 
 const MAX_IMAGES = 5;
 
@@ -335,10 +335,14 @@ export default function CommunityScreen() {
     }
   };
 
+  const onPostPressHandler = (postId: number) => {
+    console.log('postId:', postId);
+    router.push({ pathname: `(tabs)/community/${String(postId)}` });
+  };
   const renderPost: ListRenderItem<PostEx> = ({ item }) => (
     <PostCard
       data={{ ...item, category: cat === 'All' ? item.category : cat }}
-      onPress={() => router.push({ pathname: '/community/[id]', params: { id: String(item.postId) } })}
+      onPress={() => onPostPressHandler(item.postId)}
       onToggleLike={() => handleToggleLike(item.postId)}
       onToggleBookmark={() => handleToggleBookmark(item.postId)}
     />


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

게시글 클릭 시 앱이 강제종료 되는 문제 및 ProfileImage Doesn't exist 에러를 해결했습니다.

## 🔍 작업 상세 내용

> 게시글 상세보기 페이지의 ProfileImage import문 누락으로 해당 페이지 라우터가 인식되지 않았습니다.
> import문을 복원해 해당 페이지로 이동할 수 있도록 수정했습니다.

## 🏞️ 스크린샷

- X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #110
