### PR TITLE
[fix/#164] 이메일 로그인 오류 수정

### DIFF
--- a/app/(auth)/login/index.tsx
+++ b/app/(auth)/login/index.tsx
@@ -57,11 +57,16 @@ const index = () => {
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
         <Container>
           <LoginInputWrapper>
-            <Input placeholder="Enter email address" value={email} onChangeText={setEmail} label="Email" />
+            <Input
+              placeholder="Enter email address"
+              value={email}
+              onChangeText={(text) => setEmail(text)}
+              label="Email"
+            />
             <Input
               placeholder="Enter password"
               value={password}
-              onChangeText={setPassword}
+              onChangeText={(text) => setPassword(text)}
               label="Password"
               secureTextEntry
             />

--- a/app/(auth)/signup/done/index.tsx
+++ b/app/(auth)/signup/done/index.tsx
@@ -7,7 +7,7 @@ const SignUpDoneScreen = () => {
   const router = useRouter();
   const goMakeProfile = () => {
     router.dismissAll(); // 네비게이션 스택 다 비움
-    router.replace('../makeprofile/NameStepScreen');
+    router.replace('/screens/makeprofile/NameStepScreen');
   };
 
   return (

--- a/src/features/auth/hooks/useEmailLogin.ts
+++ b/src/features/auth/hooks/useEmailLogin.ts
@@ -15,7 +15,7 @@ export function useEmailLogin() {
     } catch (error) {
       throw error;
     }
-  }, []);
+  }, [email, password]);
 
   return { email, setEmail, password, setPassword, emailLogin };
 }


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

이메일 로그인 버튼이 클릭되지 않는 오류를 수정했습니다.

## 🔍 작업 상세 내용
**1️⃣ API 호출 시 아이디, 비밀번호 값이 빈 문자열('')로 들어가 422 error가 발생하는 문제를 해결했습니다.**
> useEmailLogin 내 emailLogin 함수의 의존성 배열에 email, password를 추가했습니다.
```typescript
  const emailLogin = useCallback(async () => {
    try {
      // ...
    } catch (error) {
      throw error;
    }
  }, [email, password]); // 의존성 배열에 이메일, 패스워드 추가
```
> 이메일로 로그인 페이지 내의 이메일, 패스워드 input의 onChangeText 콜백함수를 수정했습니다.
```typescript
 <Input
            ...
              // onChangeText={setPassword} // 기존
              onChangeText={(text) => setPassword(text)} // 변경
              ...
            />
```

**2️⃣ (auth)/signup/done 페이지에서 프로필 셋업 페이지로 이동 시 router.replace 경로를 수정했습니다.**



## 🏞️ 스크린샷

-   X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #164 
