### PR TITLE
[style/#166] linkedspace 모달창 개선

### DIFF
--- a/api/queryClient.ts
+++ b/api/queryClient.ts
@@ -2,11 +2,9 @@ import { QueryClient } from '@tanstack/react-query';
 
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { 
-      retry: 1, 
-      staleTime: 5_000, // 5초로 단축 (더 빠른 데이터 갱신)
-      refetchOnWindowFocus: true, // 앱이 포그라운드로 돌아올 때 refetch
-      refetchOnMount: true, // 컴포넌트 마운트 시 refetch
+    queries: {
+      retry: 1,
+      staleTime: 60_000,
     },
     mutations: { retry: 0 },
   },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -119,9 +119,13 @@ export default function RootLayout() {
   useForegroundNotification(isLoggedIn, pathname); // 포그라운드 알림 수신
   useBackgroundNotification(isLoggedIn, checkingToken); // 백그라운드 알림 수신
 
-  if (!loaded || checkingToken) return null;
+  useEffect(() => {
+    if (isLoggedIn) {
+      initializeStomp();
+    }
+  }, [isLoggedIn]);
 
-  initializeStomp(); // STOMP 초기화 함수 호출
+  if (!loaded || checkingToken) return null;
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -106,7 +106,6 @@ const BadgeText = styled.Text`
   color: ${({ theme }) => theme.colors.primary.white};
   font-family: ${({ theme }) => theme.fonts.body.B4_R.fontFamily};
   font-size: ${({ theme }) => theme.fonts.body.B4_R.fontSize}px;
-  font-weight: ${({ theme }) => theme.fonts.body.B4_R.fontWeight};
   line-height: ${({ theme }) => theme.fonts.body.B4_R.lineHeight}px;
 `;
 
@@ -114,7 +113,6 @@ const SpaceName = styled.Text`
   color: ${({ theme }) => theme.colors.primary.white};
   font-family: ${({ theme }) => theme.fonts.headline.H2_B.fontFamily};
   font-size: ${({ theme }) => theme.fonts.headline.H2_B.fontSize}px;
-  font-weight: ${({ theme }) => theme.fonts.headline.H2_B.fontWeight};
   line-height: ${({ theme }) => theme.fonts.headline.H2_B.lineHeight}px;
 `;
 
@@ -135,7 +133,6 @@ const JoinButtonText = styled.Text`
   color: ${({ theme }) => theme.colors.primary.black};
   font-family: ${({ theme }) => theme.fonts.body.B4_M.fontFamily};
   font-size: ${({ theme }) => theme.fonts.body.B4_M.fontSize}px;
-  font-weight: ${({ theme }) => theme.fonts.body.B4_M.fontWeight};
   line-height: ${({ theme }) => theme.fonts.body.B4_M.lineHeight}px;
 `;
 
@@ -156,6 +153,5 @@ const ActionText = styled.Text`
   color: ${({ theme }) => theme.colors.gray.lightGray_1};
   font-family: ${({ theme }) => theme.fonts.body.B5_M.fontFamily};
   font-size: ${({ theme }) => theme.fonts.body.B5_M.fontSize}px;
-  font-weight: ${({ theme }) => theme.fonts.body.B5_M.fontWeight};
   line-height: ${({ theme }) => theme.fonts.body.B5_M.lineHeight}px;
 `;

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { ActivityIndicator, Modal } from 'react-native';
+import CustomBottomSheet from '@/src/shared/components/CustomBottomSheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components/native';
 import { useLinkedSpaceRecommend } from '../hooks/useLinkedSpaceRecommend';
 
@@ -11,61 +12,60 @@ interface Props {
 }
 
 export const LinkedSpaceRecommendModal = ({ visible, onJoin, onDontShowToday, onClose }: Props) => {
-  const { data, isLoading } = useLinkedSpaceRecommend(visible);
+  const bottomSheetRef = useRef<BottomSheetModal | null>(null);
+  const { data } = useLinkedSpaceRecommend(visible);
+
+  // visible이 변경될 때 모달을 열거나 닫음
+  useEffect(() => {
+    if (visible && data) {
+      bottomSheetRef.current?.present();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [visible, data]);
+
   // data가 없으면 모달을 렌더링하지 않음
-  if (!visible || (!isLoading && !data)) {
+  if (!visible || !data) {
     return null;
   }
 
   return (
-    <Modal transparent visible={visible} animationType="slide" onRequestClose={onClose}>
-      <ModalBackground>
-        <BottomSheet>
-          <ModalCard source={require('@/assets/images/background2.png')}>
-            {isLoading ? (
-              <LoadingContainer>
-                <ActivityIndicator color="#fff" size="large" />
-              </LoadingContainer>
-            ) : data ? (
-              <ContentContainer>
-                <LeftSection>
-                  <LeftTextSection>
-                    <BadgeText>Trending space</BadgeText>
-                    <SpaceName numberOfLines={2}>{data.roomName}</SpaceName>
-                  </LeftTextSection>
-                  <JoinButton onPress={() => onJoin(String(data.roomId), data.roomName)} activeOpacity={0.8}>
-                    <JoinButtonText>Join</JoinButtonText>
-                  </JoinButton>
-                </LeftSection>
+    <CustomBottomSheet ref={bottomSheetRef} backgroundColor="transparent">
+      <BottomSheetContent>
+        <ModalCard source={require('@/assets/images/background2.png')}>
+          {data ? (
+            <ContentContainer>
+              <LeftSection>
+                <LeftTextSection>
+                  <BadgeText>Trending space</BadgeText>
+                  <SpaceName numberOfLines={2}>{data.roomName}</SpaceName>
+                </LeftTextSection>
+                <JoinButton onPress={() => onJoin(String(data.roomId), data.roomName)} activeOpacity={0.8}>
+                  <JoinButtonText>Join</JoinButtonText>
+                </JoinButton>
+              </LeftSection>
 
-                <RightSection>
-                  <SpaceImage source={{ uri: data.roomImageUrl }} />
-                </RightSection>
-              </ContentContainer>
-            ) : null}
-          </ModalCard>
+              <RightSection>
+                <SpaceImage source={{ uri: data.roomImageUrl }} />
+              </RightSection>
+            </ContentContainer>
+          ) : null}
+        </ModalCard>
 
-          <BottomActions>
-            <ActionButton onPress={onDontShowToday} activeOpacity={0.7}>
-              <ActionText>Don't Show again today</ActionText>
-            </ActionButton>
-            <ActionButton onPress={onClose} activeOpacity={0.7}>
-              <ActionText>Close</ActionText>
-            </ActionButton>
-          </BottomActions>
-        </BottomSheet>
-      </ModalBackground>
-    </Modal>
+        <BottomActions>
+          <ActionButton onPress={onDontShowToday} activeOpacity={0.7}>
+            <ActionText>Don't Show again today</ActionText>
+          </ActionButton>
+          <ActionButton onPress={onClose} activeOpacity={0.7}>
+            <ActionText>Close</ActionText>
+          </ActionButton>
+        </BottomActions>
+      </BottomSheetContent>
+    </CustomBottomSheet>
   );
 };
 
-const ModalBackground = styled.View`
-  flex: 1;
-  justify-content: flex-end;
-  background-color: rgba(0, 0, 0, 0.7);
-`;
-
-const BottomSheet = styled.View`
+const BottomSheetContent = styled.View`
   width: 100%;
   border-top-left-radius: 22px;
   border-top-right-radius: 22px;
@@ -73,17 +73,11 @@ const BottomSheet = styled.View`
 
 const ModalCard = styled.ImageBackground`
   width: 100%;
-  min-height: 28%;
+  min-height: 300px;
   justify-content: center;
-  border-top-left-radius: 22px;
-  border-top-right-radius: 22px;
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
   overflow: hidden;
-`;
-
-const LoadingContainer = styled.View`
-  min-height: 150px;
-  justify-content: center;
-  align-items: center;
 `;
 
 const ContentContainer = styled.View`
@@ -102,7 +96,7 @@ const LeftTextSection = styled.View`
 
 const LeftSection = styled.View`
   flex: 1;
-  gap: 32px;
+  gap: 28px;
   max-width: 40%;
 `;
 
@@ -111,16 +105,19 @@ const RightSection = styled.View`
 `;
 
 const BadgeText = styled.Text`
-  color: #ffffff;
-  font-size: 18px;
-  font-weight: 400;
+  color: ${({ theme }) => theme.colors.primary.white};
+  font-family: ${({ theme }) => theme.fonts.body.B4_R.fontFamily};
+  font-size: ${({ theme }) => theme.fonts.body.B4_R.fontSize}px;
+  font-weight: ${({ theme }) => theme.fonts.body.B4_R.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.B4_R.lineHeight}px;
 `;
 
 const SpaceName = styled.Text`
-  color: #ffffff;
-  font-size: 32px;
-  font-weight: bold;
-  line-height: 42px;
+  color: ${({ theme }) => theme.colors.primary.white};
+  font-family: ${({ theme }) => theme.fonts.headline.H2_B.fontFamily};
+  font-size: ${({ theme }) => theme.fonts.headline.H2_B.fontSize}px;
+  font-weight: ${({ theme }) => theme.fonts.headline.H2_B.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.headline.H2_B.lineHeight}px;
 `;
 
 const SpaceImage = styled.Image`
@@ -130,17 +127,18 @@ const SpaceImage = styled.Image`
 `;
 
 const JoinButton = styled.TouchableOpacity`
-  background-color: #02F59B;
+  background-color: ${({ theme }) => theme.colors.primary.mint};
   padding: 16px 30px;
   border-radius: 10px;
   align-self: flex-start;
 `;
 
 const JoinButtonText = styled.Text`
-  color: #1D1E1F;
-  font-weight: 500;
-  font-size: 16px;
-  letter-spacing: 0.3px;
+  color: ${({ theme }) => theme.colors.primary.black};
+  font-family: ${({ theme }) => theme.fonts.body.B4_M.fontFamily};
+  font-size: ${({ theme }) => theme.fonts.body.B4_M.fontSize}px;
+  font-weight: ${({ theme }) => theme.fonts.body.B4_M.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.B4_M.lineHeight}px;
 `;
 
 const BottomActions = styled.View`
@@ -149,7 +147,7 @@ const BottomActions = styled.View`
   justify-content: space-between;
   padding: 16px 5%;
   padding-bottom: 32px;
-  background-color: #171818;
+  background-color: ${({ theme }) => theme.colors.gray.darkBlack_1};
 `;
 
 const ActionButton = styled.TouchableOpacity`
@@ -157,7 +155,9 @@ const ActionButton = styled.TouchableOpacity`
 `;
 
 const ActionText = styled.Text`
-  color: #CCCFD0;
-  font-size: 14px;
-  font-weight: 500;
+  color: ${({ theme }) => theme.colors.gray.lightGray_1};
+  font-family: ${({ theme }) => theme.fonts.body.B5_M.fontFamily};
+  font-size: ${({ theme }) => theme.fonts.body.B5_M.fontSize}px;
+  font-weight: ${({ theme }) => theme.fonts.body.B5_M.fontWeight};
+  line-height: ${({ theme }) => theme.fonts.body.B5_M.lineHeight}px;
 `;

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -104,16 +104,12 @@ const RightSection = styled.View`
 
 const BadgeText = styled.Text`
   color: ${({ theme }) => theme.colors.primary.white};
-  font-family: ${({ theme }) => theme.fonts.body.B4_R.fontFamily};
-  font-size: ${({ theme }) => theme.fonts.body.B4_R.fontSize}px;
-  line-height: ${({ theme }) => theme.fonts.body.B4_R.lineHeight}px;
+  ${({ theme }) => theme.fonts.body.B4_R};
 `;
 
 const SpaceName = styled.Text`
   color: ${({ theme }) => theme.colors.primary.white};
-  font-family: ${({ theme }) => theme.fonts.headline.H2_B.fontFamily};
-  font-size: ${({ theme }) => theme.fonts.headline.H2_B.fontSize}px;
-  line-height: ${({ theme }) => theme.fonts.headline.H2_B.lineHeight}px;
+  ${({ theme }) => theme.fonts.headline.H2_B};
 `;
 
 const SpaceImage = styled.Image`
@@ -131,9 +127,7 @@ const JoinButton = styled.TouchableOpacity`
 
 const JoinButtonText = styled.Text`
   color: ${({ theme }) => theme.colors.primary.black};
-  font-family: ${({ theme }) => theme.fonts.body.B4_M.fontFamily};
-  font-size: ${({ theme }) => theme.fonts.body.B4_M.fontSize}px;
-  line-height: ${({ theme }) => theme.fonts.body.B4_M.lineHeight}px;
+  ${({ theme }) => theme.fonts.body.B4_M};
 `;
 
 const BottomActions = styled.View`
@@ -151,7 +145,5 @@ const ActionButton = styled.TouchableOpacity`
 
 const ActionText = styled.Text`
   color: ${({ theme }) => theme.colors.gray.lightGray_1};
-  font-family: ${({ theme }) => theme.fonts.body.B5_M.fontFamily};
-  font-size: ${({ theme }) => theme.fonts.body.B5_M.fontSize}px;
-  line-height: ${({ theme }) => theme.fonts.body.B5_M.lineHeight}px;
+  ${({ theme }) => theme.fonts.body.B5_M};
 `;

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -33,23 +33,21 @@ export const LinkedSpaceRecommendModal = ({ visible, onJoin, onDontShowToday, on
     <CustomBottomSheet ref={bottomSheetRef} backgroundColor="transparent">
       <BottomSheetContent>
         <ModalCard source={require('@/assets/images/background2.png')}>
-          {data ? (
-            <ContentContainer>
-              <LeftSection>
-                <LeftTextSection>
-                  <BadgeText>Trending space</BadgeText>
-                  <SpaceName numberOfLines={2}>{data.roomName}</SpaceName>
-                </LeftTextSection>
-                <JoinButton onPress={() => onJoin(String(data.roomId), data.roomName)} activeOpacity={0.8}>
-                  <JoinButtonText>Join</JoinButtonText>
-                </JoinButton>
-              </LeftSection>
+          <ContentContainer>
+            <LeftSection>
+              <LeftTextSection>
+                <BadgeText>Trending space</BadgeText>
+                <SpaceName numberOfLines={2}>{data.roomName}</SpaceName>
+              </LeftTextSection>
+              <JoinButton onPress={() => onJoin(String(data.roomId), data.roomName)} activeOpacity={0.8}>
+                <JoinButtonText>Join</JoinButtonText>
+              </JoinButton>
+            </LeftSection>
 
-              <RightSection>
-                <SpaceImage source={{ uri: data.roomImageUrl }} />
-              </RightSection>
-            </ContentContainer>
-          ) : null}
+            <RightSection>
+              <SpaceImage source={{ uri: data.roomImageUrl }} />
+            </RightSection>
+          </ContentContainer>
         </ModalCard>
 
         <BottomActions>

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -30,7 +30,7 @@ export const LinkedSpaceRecommendModal = ({ visible, onJoin, onDontShowToday, on
   }
 
   return (
-    <CustomBottomSheet ref={bottomSheetRef} backgroundColor="transparent">
+    <CustomBottomSheet ref={bottomSheetRef} backgroundColor="transparent" handleComponent={() => null}>
       <BottomSheetContent>
         <ModalCard source={require('@/assets/images/background2.png')}>
           <ContentContainer>

--- a/src/shared/components/CustomBottomSheet.tsx
+++ b/src/shared/components/CustomBottomSheet.tsx
@@ -7,9 +7,16 @@ interface CustomBottomSheetProps {
   ref: React.RefObject<BottomSheetModal | null>;
   onChange?: (index: number) => void;
   backgroundColor?: string;
+  handleComponent?: () => null;
 }
 
-const CustomBottomSheet = ({ children, ref, onChange, backgroundColor }: CustomBottomSheetProps) => {
+const CustomBottomSheet = ({
+  children,
+  ref,
+  onChange,
+  backgroundColor = theme.colors.gray.darkGray_1,
+  handleComponent = () => null,
+}: CustomBottomSheetProps) => {
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.6} pressBehavior="close" />
@@ -18,14 +25,14 @@ const CustomBottomSheet = ({ children, ref, onChange, backgroundColor }: CustomB
   );
 
   const bottomSheetModalStyle = {
-    backgroundColor: backgroundColor ?? theme.colors.gray.darkGray_1,
+    backgroundColor: backgroundColor,
   } as const;
 
   const bottomSheetHandleStyle = {
-    backgroundColor: backgroundColor ?? theme.colors.gray.gray_1,
+    backgroundColor: backgroundColor,
   } as const;
 
-  const bottomSheetViewStyle = { flex: 1, backgroundColor: backgroundColor ?? theme.colors.gray.darkGray_1 } as const;
+  const bottomSheetViewStyle = { flex: 1, backgroundColor: backgroundColor } as const;
 
   return (
     <BottomSheetModal
@@ -34,7 +41,7 @@ const CustomBottomSheet = ({ children, ref, onChange, backgroundColor }: CustomB
       backgroundStyle={bottomSheetModalStyle}
       handleIndicatorStyle={bottomSheetHandleStyle}
       backdropComponent={renderBackdrop}
-      handleComponent={() => null} // 핸들 숨기기
+      handleComponent={handleComponent} // 핸들 숨기기
     >
       <BottomSheetView style={bottomSheetViewStyle}>{children}</BottomSheetView>
     </BottomSheetModal>

--- a/src/shared/components/CustomBottomSheet.tsx
+++ b/src/shared/components/CustomBottomSheet.tsx
@@ -1,20 +1,31 @@
-import React, { ReactElement, useCallback } from 'react';
-import { BottomSheetBackdrop, BottomSheetBackdropProps, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { theme } from '@/src/styles/theme';
+import { BottomSheetBackdrop, BottomSheetBackdropProps, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
+import React, { ReactElement, useCallback } from 'react';
 
 interface CustomBottomSheetProps {
   children: ReactElement;
   ref: React.RefObject<BottomSheetModal | null>;
   onChange?: (index: number) => void;
+  backgroundColor?: string;
 }
 
-const CustomBottomSheet = ({ children, ref, onChange }: CustomBottomSheetProps) => {
+const CustomBottomSheet = ({ children, ref, onChange, backgroundColor }: CustomBottomSheetProps) => {
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.6} pressBehavior="close" />
     ),
     [],
   );
+
+  const bottomSheetModalStyle = {
+    backgroundColor: backgroundColor ?? theme.colors.gray.darkGray_1,
+  } as const;
+
+  const bottomSheetHandleStyle = {
+    backgroundColor: backgroundColor ?? theme.colors.gray.gray_1,
+  } as const;
+
+  const bottomSheetViewStyle = { flex: 1, backgroundColor: backgroundColor ?? theme.colors.gray.darkGray_1 } as const;
 
   return (
     <BottomSheetModal
@@ -23,20 +34,11 @@ const CustomBottomSheet = ({ children, ref, onChange }: CustomBottomSheetProps) 
       backgroundStyle={bottomSheetModalStyle}
       handleIndicatorStyle={bottomSheetHandleStyle}
       backdropComponent={renderBackdrop}
+      handleComponent={() => null} // 핸들 숨기기
     >
       <BottomSheetView style={bottomSheetViewStyle}>{children}</BottomSheetView>
     </BottomSheetModal>
   );
 };
-
-const bottomSheetModalStyle = {
-  backgroundColor: theme.colors.gray.darkGray_1,
-} as const;
-
-const bottomSheetHandleStyle = {
-  backgroundColor: theme.colors.gray.gray_1,
-} as const;
-
-const bottomSheetViewStyle = { flex: 1, backgroundColor: theme.colors.gray.darkGray_1 } as const;
 
 export default CustomBottomSheet;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -55,7 +55,6 @@ type Font = {
 const FONT = ({ fontFamily, size, weight, lineHeight }: Font) => {
   return {
     fontFamily: (FONT_FAMILY[fontFamily] as any)[weight],
-    fontWeight: weight,
     fontSize: size,
     lineHeight: lineHeight,
   };

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -55,6 +55,7 @@ type Font = {
 const FONT = ({ fontFamily, size, weight, lineHeight }: Font) => {
   return {
     fontFamily: (FONT_FAMILY[fontFamily] as any)[weight],
+    fontWeight: weight,
     fontSize: size,
     lineHeight: lineHeight,
   };


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   링크드 스페이스 모달창 UI를 개선하였습니다.

## 🔍 작업 상세 내용

1.   공통 바텀 시트 속성을 수정하였습니다.
```typescript
interface CustomBottomSheetProps {
  children: ReactElement;
  ref: React.RefObject<BottomSheetModal | null>;
  onChange?: (index: number) => void;
  backgroundColor?: string;   //추가
handleComponent?: () => null; //추가
}
```
* 속성 지정을 하지 않을 경우 기본 값이 설정됩니다.
```typescript
const CustomBottomSheet = ({
  children,
  ref,
  onChange,
  backgroundColor = theme.colors.gray.darkGray_1,
  handleComponent = () => null,
}: CustomBottomSheetProps) => {
...
}
```
* 투명 속성은 backgroundColor="transparent" 를 이용하면 됩니다.
---
2.   링크드 스페이스 모달창에 공통 바텀 시트를 적용하였습니다.
3.   링크드 스페이스 모달창에 theme 스타일 속성을 적용하였습니다.
4.   error로 인한 링크드 스페이스 모달창 데이터가 없을 경우 로딩창을 포함하여 렌더링을 막았습니다.
---
5. 현재 신고 기능이 제한되는 것으로 알고 있어 링크드 스페이스 디테일 페이지의 신고 아이콘 수정은 진행하지 않았습니다.

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #166 
