### PR TITLE
[Hotfix/#173] linked space modal 수정

### DIFF
--- a/src/features/chat/list/components/MyChatList.tsx
+++ b/src/features/chat/list/components/MyChatList.tsx
@@ -54,19 +54,19 @@ export const MyChatList = ({ data }: { data: MyChatRoom }) => {
 
 // 스타일 정의
 const ChatRoomWrapper = styled.View`
-  background-color: #1d1e1f;
+  background-color: ${({ theme }) => theme.colors.primary.black};
   height: 80px;
   justify-content: center;
 `;
 
 const RoomBox = styled.TouchableOpacity`
-  background-color: #1d1e1f;
+  background-color: ${({ theme }) => theme.colors.primary.black};
   padding-top: 8px;
   height: 80px;
   flex-direction: row;
   align-items: center;
   border-bottom-width: 1px;
-  border-bottom-color: #353637;
+  border-bottom-color: ${({ theme }) => theme.colors.gray.darkGray_1};
 `;
 
 const RoomImageContainer = styled.View`
@@ -112,37 +112,32 @@ const ChatPeopleContainer = styled.View`
 `;
 
 const ChatPerson = styled.Text`
-  font-size: 16px;
   margin-left: 5px;
-  font-family: 'PlusJakartaSans_500Medium';
-  color: #ffffff;
+  ${({ theme }) => theme.fonts.body.B2_M};
+  color: ${({ theme }) => theme.colors.primary.white};
   flex-shrink: 1;
 `;
 
 const ChatPeople = styled.Text`
-  font-size: 14px;
   margin-left: 8px;
-  font-family: 'PlusJakartaSans_500Medium';
-  color: #02f59b;
+  ${({ theme }) => theme.fonts.body.B5_M};
+  color: ${({ theme }) => theme.colors.primary.mint};
 `;
 
 const ChatTime = styled.Text`
-  margin-top: 5px;
-  font-size: 11px;
-  font-family: 'PlusJakartaSans_300Light';
-  color: #ffffff;
+  ${({ theme }) => theme.fonts.small.small_L};
+  color: ${({ theme }) => theme.colors.primary.white};
 `;
 
 const ChatContent = styled.Text<{ textColor?: boolean }>`
-  font-size: 13px;
-  margin-left: 1px;
-  color: ${(props) => (props.textColor ? '#ffffff' : '#848687')};
-  font-family: 'PlusJakartaSans_300Light';
+  margin-left: 5px;
+  color: ${(props) => (props.textColor ? `${props.theme.colors.primary.white}` : `${props.theme.colors.gray.gray_1}`)};
+  ${({ theme }) => theme.fonts.body.B4_L};
   flex: 1;
 `;
 
 const ChatCountBox = styled.View`
-  background-color: #02f59b;
+  background-color: ${({ theme }) => theme.colors.primary.mint};
   width: 23px;
   height: 23px;
   align-items: center;
@@ -151,7 +146,7 @@ const ChatCountBox = styled.View`
 `;
 
 const ChatCount = styled.Text`
-  font-family: 'PlusJakartaSans_600SemiBold';
+  ${({ theme }) => theme.fonts.small.small_SB};
   font-size: 9px;
-  color: #1d1e1f;
+  color: ${({ theme }) => theme.colors.primary.black};
 `;

--- a/src/features/chat/member/components/MemberItem.tsx
+++ b/src/features/chat/member/components/MemberItem.tsx
@@ -88,14 +88,14 @@ const HostBox = styled.View`
 `;
 
 const HostText = styled.Text`
-  color: #ffffff;
+  color: ${({ theme }) => theme.colors.primary.white};
   font-size: 11px;
-  font-family: PlusJakartaSans_500Medium;
+  ${theme.fonts.small.small_M}
+  ${({ theme }) => theme.fonts.small.small_M};
 `;
 
 const MemberNameText = styled.Text`
   margin-left: 12px;
-  color: #ffffff;
-  font-family: PlusJakartaSans_500Medium;
-  font-size: 14px;
+  color: ${({ theme }) => theme.colors.primary.white};
+  ${({ theme }) => theme.fonts.body.B4_M};
 `;

--- a/src/features/chat/member/components/MemberItem.tsx
+++ b/src/features/chat/member/components/MemberItem.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/components/common/Icon';
+import RawProfileImage from '@/components/common/ProfileImage';
 import { theme } from '@/src/styles/theme';
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
@@ -21,7 +22,7 @@ export const MemberItem: React.FC<MemberItemProps> = ({ name, isHost, imageUrl, 
     <MemberContainer>
       <TouchableOpacity onPress={onPressProfile}>
         <ProfileBox>
-          <ProfileImage source={imageUrl ? { uri: imageUrl } : require('@/assets/images/character1.png')} />
+          <ProfileImage source={{ uri: imageUrl }} />
         </ProfileBox>
       </TouchableOpacity>
 
@@ -57,7 +58,7 @@ const ProfileBox = styled.View`
   border-radius: 30px;
 `;
 
-const ProfileImage = styled.Image`
+const ProfileImage = styled(RawProfileImage)`
   width: 100%;
   height: 100%;
 `;

--- a/src/features/find/hooks/useLinkedSpaceRecommendModal.ts
+++ b/src/features/find/hooks/useLinkedSpaceRecommendModal.ts
@@ -32,6 +32,7 @@ export const useLinkedSpaceRecommendModal = () => {
         pathname: CHAT_ROUTE(roomId),
         params: { roomName },
       });
+      setVisible(false);
     } catch (error: any) {
       if (error.response?.status === 428) {
         setProfileModalVisible(true);


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-  링크드 스페이스 추천 모달의 join 클릭시 모달 off
-  채팅 멤버 페이지의 프로필 아이콘에 대해 공통 컴포넌트 적용 및 theme 적용
-  채팅 목록 style 수정

## 🔍 작업 상세 내용
```typescript
// src/features/find/hooks/useLinkedSpaceRecommendModal.ts
const handleJoin = async (roomId: string, roomName: string) => {
    try {
      await joinLinkedSpace(roomId);
      queryClient.invalidateQueries({ queryKey: CHAT_ROOMS_QUERY_KEY });
      router.push({
        pathname: CHAT_ROUTE(roomId),
        params: { roomName },
      });
      setVisible(false);   //추가: route 변경 후 상태 변경
    } catch (error: any) {
      if (error.response?.status === 428) {
        setProfileModalVisible(true);
        return;
      }
```

```typescript
// src/features/chat/member/components/MemberItem.tsx
import RawProfileImage from '@/components/common/ProfileImage';
...
<ProfileImage source={{ uri: imageUrl }} />
...
const ProfileImage = styled(RawProfileImage)`
  width: 100%;
  height: 100%;
`;
```

## 🔗 관련 이슈

Closes #173 #174 
