### PR TITLE
[Feat] 마이페이지에서 유저 피드백, 버그 리포트 페이지로 이동하는 기능 추가

### DIFF
--- a/app/(tabs)/mypage/index.tsx
+++ b/app/(tabs)/mypage/index.tsx
@@ -1,11 +1,12 @@
 import api from '@/api/axiosInstance';
 import Icon from '@/components/common/Icon';
 import ProfileImage from '@/components/common/ProfileImage';
-import CustomButton from '@/src/shared/components/CustomButton';
 import { useDeleteAccount } from '@/hooks/mutations/useDeleteAccount';
 import { useUpdateProfile } from '@/hooks/mutations/useUpdateProfile';
 import useMyProfile from '@/hooks/queries/useMyProfile';
 import { uploadLocalImageAndGetKey } from '@/lib/mypage/uploadImage';
+import SupportButton from '@/src/features/mypage/components/SupportButton';
+import CustomButton from '@/src/shared/components/CustomButton';
 import { Config } from '@/src/shared/constants/config';
 import { AUTH_ROUTE } from '@/src/shared/constants/route';
 import { theme } from '@/src/styles/theme';
@@ -362,6 +363,9 @@ export default function MyPageScreen() {
           <Icon type="next" size={20} color={theme.colors.primary.white} />
         </RowLink>
         <RowSeparator />
+
+        {/* 피드백, 버그 리포트 페이지 이동 버튼 */}
+        <SupportButton />
 
         <SectionTitleRow>
           <SectionTitleIconAccount />

--- a/app/mypage/support/index.tsx
+++ b/app/mypage/support/index.tsx
@@ -1,0 +1,104 @@
+import Icon from '@/components/common/Icon';
+import ReportButton from '@/src/features/mypage/components/ReportButton';
+import { useGetSupportUrl } from '@/src/features/mypage/hooks/useGetSupportUrl';
+import { textStyle, theme } from '@/src/styles/theme';
+import { openURL } from 'expo-linking';
+import { router } from 'expo-router';
+import React from 'react';
+import { ActivityIndicator } from 'react-native';
+import styled from 'styled-components/native';
+
+const SupportPage = () => {
+  const { data, isLoading, isError, refetch } = useGetSupportUrl();
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <Content center={true}>
+          <ActivityIndicator size="large" />
+        </Content>
+      );
+    }
+
+    if (isError || !data) {
+      return (
+        <Content center={true}>
+          <Text>Failed to load support page.</Text>
+          <ErrorButton onPress={() => refetch()} activeOpacity={0.8}>
+            <ErrorButtonText>Retry</ErrorButtonText>
+          </ErrorButton>
+        </Content>
+      );
+    }
+
+    return (
+      <Content center={false}>
+        <ReportButton
+          title="User Feedback"
+          description="Share your thoughts about our app"
+          onPress={() => openURL(data.feedbackUrl)}
+        />
+
+        <ReportButton title="Report a Bug" onPress={() => openURL(data.bugReportUrl)} />
+      </Content>
+    );
+  };
+
+  return (
+    <Safe>
+      <Header>
+        <IconBtn onPress={() => router.back()} activeOpacity={0.8}>
+          <Icon type="previous" size={24} color={theme.colors.gray.lightGray_1} />
+        </IconBtn>
+        <HeaderTitle>Feedback & Support</HeaderTitle>
+      </Header>
+
+      {renderContent()}
+    </Safe>
+  );
+};
+
+export default SupportPage;
+
+const Safe = styled.SafeAreaView`
+  flex: 1;
+  background-color: ${({ theme }) => theme.colors.primary.black};
+`;
+const Header = styled.View`
+  padding: 10px 20px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  margin-bottom: 16px;
+`;
+const IconBtn = styled.TouchableOpacity`
+  padding: 5px;
+  position: absolute;
+  left: 15px;
+`;
+const HeaderTitle = styled.Text`
+  padding: 6px 38px;
+  color: ${({ theme }) => theme.colors.primary.white};
+  ${({ theme }) => textStyle(theme.fonts.body.B2_M)};
+`;
+const Content = styled.View<{ center?: boolean }>`
+  flex: 1;
+  padding: 0 20px;
+  align-items: ${({ center }) => (center ? 'center' : 'stretch')};
+  justify-content: ${({ center }) => (center ? 'center' : 'flex-start')};
+`;
+const Text = styled.Text`
+  color: ${({ theme }) => theme.colors.primary.white};
+  ${({ theme }) => textStyle(theme.fonts.body.B3_M)};
+`;
+const ErrorButton = styled.TouchableOpacity`
+  margin-top: 12px;
+  padding: 10px 16px;
+  background-color: ${({ theme }) => theme.colors.primary.mint};
+  border-radius: 6px;
+`;
+const ErrorButtonText = styled.Text`
+  color: ${({ theme }) => theme.colors.primary.black};
+  ${({ theme }) => textStyle(theme.fonts.body.B3_M)};
+`;

--- a/app/mypage/support/index.tsx
+++ b/app/mypage/support/index.tsx
@@ -1,8 +1,8 @@
 import Icon from '@/components/common/Icon';
 import ReportButton from '@/src/features/mypage/components/ReportButton';
 import { useGetSupportUrl } from '@/src/features/mypage/hooks/useGetSupportUrl';
+import { openURL } from '@/src/shared/utils/confirmOpenURL';
 import { textStyle, theme } from '@/src/styles/theme';
-import { openURL } from 'expo-linking';
 import { router } from 'expo-router';
 import React from 'react';
 import { ActivityIndicator } from 'react-native';

--- a/src/features/mypage/api/support.ts
+++ b/src/features/mypage/api/support.ts
@@ -1,0 +1,11 @@
+import api from '@/api/axiosInstance';
+
+type SupportLinksResponse = {
+  feedbackUrl: string;
+  bugReportUrl: string;
+};
+
+export const getSupportLinks = async (): Promise<SupportLinksResponse> => {
+  const res = await api.get('/api/v1/mypage/support-links');
+  return res.data;
+};

--- a/src/features/mypage/components/ReportButton.tsx
+++ b/src/features/mypage/components/ReportButton.tsx
@@ -1,0 +1,51 @@
+import Icon from '@/components/common/Icon';
+import { theme } from '@/src/styles/theme';
+import React from 'react';
+import styled from 'styled-components/native';
+
+type ReportButtonProps = {
+  title: string;
+  description?: string;
+  onPress?: () => void;
+};
+
+const ReportButton = ({ title, description, onPress }: ReportButtonProps) => {
+  return (
+    <Container onPress={onPress}>
+      <TextContainer>
+        <Title>{title}</Title>
+        {description && <Description>{description}</Description>}
+      </TextContainer>
+
+      <IconBtn>
+        <Icon type="next" size={24} color={theme.colors.primary.white} />
+      </IconBtn>
+    </Container>
+  );
+};
+
+export default ReportButton;
+
+const Container = styled.Pressable`
+  justify-content: space-between;
+  flex-direction: row;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom-width: 1px;
+  border-bottom-color: ${({ theme }) => theme.colors.gray.darkGray_1};
+`;
+const TextContainer = styled.View`
+  padding: 16px 0;
+  gap: 3px;
+`;
+const IconBtn = styled.View`
+  padding: 5px;
+`;
+const Title = styled.Text`
+  color: ${({ theme }) => theme.colors.primary.white};
+  ${({ theme }) => theme.fonts.body.B3_M};
+`;
+const Description = styled.Text`
+  color: ${({ theme }) => theme.colors.gray.lightGray_1};
+  ${({ theme }) => theme.fonts.body.B4_L};
+`;

--- a/src/features/mypage/components/SupportButton.tsx
+++ b/src/features/mypage/components/SupportButton.tsx
@@ -1,0 +1,72 @@
+import Icon from '@/components/common/Icon';
+import { MYPAGE_SUPPORT_ROUTE } from '@/src/shared/constants/route';
+import { textStyle, theme } from '@/src/styles/theme';
+import { router } from 'expo-router';
+import React from 'react';
+import styled from 'styled-components/native';
+
+const SupportButton = () => {
+  return (
+    <Container>
+      <Title>
+        <Icon type="info" size={16} color={theme.colors.gray.gray_1} />
+        <TitleText>Support</TitleText>
+      </Title>
+
+      <RedirectButton onPress={() => router.push(MYPAGE_SUPPORT_ROUTE)}>
+        <RedirectText>Feedback & Support</RedirectText>
+        <Icon type="next" size={20} color={theme.colors.primary.white} />
+      </RedirectButton>
+    </Container>
+  );
+};
+
+export default SupportButton;
+
+const Container = styled.View`
+  gap: 20px;
+  border-bottom-width: 1px;
+  padding-bottom: 20px;
+
+  /* 리팩토링 전 마진값, divider색상 */
+  margin: 28px 16px;
+  border-bottom-color: #2a2b2c;
+
+  /* 리팩토링 후에는 이렇게 or index.tsx에 따라 수정해주세요 */
+  /* margin: 40px 20px; 
+  border-bottom-color: ${({ theme }) => theme.colors.gray.darkGray_1}; */
+`;
+const Title = styled.View`
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+`;
+const TitleText = styled.Text`
+  /* 아래는 리팩토링 전 마이페이지 스타일과 맞추기 위한 것이므로 리팩토링 시 삭제해주세요 */
+  color: #9aa0a6;
+  font-size: 14px;
+  line-height: 18px;
+  letter-spacing: 0.2px;
+  font-family: 'PlusJakartaSans_600SemiBold';
+
+  /* 이 스타일 사용하시면 됩니다! */
+  /* color: ${({ theme }) => theme.colors.gray.gray_1};
+  ${({ theme }) => textStyle(theme.fonts.body.B5_SB)} */
+`;
+const RedirectButton = styled.Pressable`
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+const RedirectText = styled.Text`
+  /* 아래는 리팩토링 전 마이페이지 스타일과 맞추기 위한 것이므로 리팩토링 시 삭제해주세요 */
+  color: #e9ecef;
+  font-size: 15px;
+  font-family: 'PlusJakartaSans_400Regular';
+
+  /* 이 스타일 사용하시면 됩니다! */
+  /* color: ${({ theme }) => theme.colors.primary.white};
+  ${({ theme }) => textStyle(theme.fonts.body.B2_M)} */
+`;

--- a/src/features/mypage/hooks/useGetSupportUrl.ts
+++ b/src/features/mypage/hooks/useGetSupportUrl.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSupportLinks } from '../api/support';
+
+export const useGetSupportUrl = () => {
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['support-links'],
+    queryFn: () => getSupportLinks(),
+  });
+
+  return { data, isLoading, isError, refetch };
+};

--- a/src/shared/constants/route.ts
+++ b/src/shared/constants/route.ts
@@ -28,3 +28,6 @@ export const COMMUNITY_ROUTER = {
   BOOKMARK: '/community/bookmark-list',
   DETAIL: '/community/detail/[id]',
 } as const;
+
+// 마이페이지 route 경로
+export const MYPAGE_SUPPORT_ROUTE = toRoute('/mypage/support');

--- a/src/shared/utils/confirmOpenURL.ts
+++ b/src/shared/utils/confirmOpenURL.ts
@@ -38,3 +38,12 @@ export const confirmOpenURL = async (url: string): Promise<boolean> => {
     );
   });
 };
+
+export const openURL = async (url: string) => {
+  const supported = await Linking.canOpenURL(url);
+  if (supported) {
+    await Linking.openURL(url);
+  } else {
+    Alert.alert('Invalid URL', `Cannot open the URL: ${url}`);
+  }
+};


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   유저 피드백, 버그 리포트 페이지 이동 기능 추가

## 🔍 작업 상세 내용
### 1. 새로운 폴더 및 파일 생성
-   src/features/mypage 폴더 안에 api, hooks, components 폴더를 만들어서 작업했습니다
- app/mypage/support/index.tsx 페이지를 생성했습니다. 

(혹시나 해서 자세히 적습니다...)
```
====app====
📦mypage
 ┗ 📂support
 ┃ ┗ 📜index.tsx

====src/features====
📦mypage
 ┣ 📂api
 ┣ 📂components
 ┗ 📂hooks
```
### 2. 기능 동작 과정(아래 스크린샷 참고)
  - 마이페이지에서 Feedback&Support 버튼 클릭 시 Feedback&Support 페이지로 이동
  - Feedback&Support 페이지에서 피드백, 버그 리포트 페이지 url 데이터 호출
  - 각 버튼 클릭 시 외부 리포트 폼으로 이동

### 3. ⚠️  스타일 적용
- 마이페이지 리팩토링이 되지 않은 상태로, `SupportButton.tsx`는 다른 버튼과의 통일성을 위해 기존 스타일을 따라 적용했습니다.
해당 파일에는 주석으로 리팩토링 이후 삭제해야 하는 스타일을 명시해두었습니다. 확인 부탁드립니다!

## 🏞️ 스크린샷

- 추가 기능 스크린샷
<div align='left'>
  <img src='https://github.com/user-attachments/assets/e147a583-9820-4a67-ac07-e1009f665a1b' width=20% />
  <img src='https://github.com/user-attachments/assets/d7e7aef2-eca2-4e01-b7f6-ab135739eb00' width=20% />
</div>

## ✅ 체크리스트

-   [x] 빌드가 실패 없이 완료되었나요?
-   [x] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [x] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [x] 불필요한 console.log, 주석을 제거했나요?
-   [x] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #179 
