### PR TITLE
[Feat/#177] 링크드 스페이스 생성 시 제목 길이 제한

### DIFF
--- a/src/features/linked-space/create/components/SpaceFormInputs.tsx
+++ b/src/features/linked-space/create/components/SpaceFormInputs.tsx
@@ -1,5 +1,5 @@
 import Icon from '@/components/common/Icon';
-import { theme } from '@/src/styles/theme';
+import { textStyle, theme } from '@/src/styles/theme';
 import React from 'react';
 import styled from 'styled-components/native';
 import { DEFAULT_AVATARS, SPACE_DESCRIPTION_MAX_LENGTH, SPACE_NAME_MAX_LENGTH } from '../constants';
@@ -59,7 +59,7 @@ export const SpaceFormInputs: React.FC<SpaceFormInputsProps> = ({
           value={description}
           onChangeText={onDescriptionChange}
           placeholder="Describe space here"
-          placeholderTextColor="#848687"
+          placeholderTextColor={theme.colors.gray.gray_1}
           returnKeyType="done"
           multiline
           submitBehavior="blurAndSubmit"
@@ -94,7 +94,7 @@ const CameraContainer = styled.View`
   width: 32px;
   height: 32px;
   border-radius: 30px;
-  background-color: #02f59b;
+  background-color: ${theme.colors.primary.mint};
   justify-content: center;
   align-items: center;
   z-index: 999;
@@ -115,23 +115,20 @@ const SpaceNameContainer = styled.View`
 `;
 
 const SpaceNameText = styled.Text`
-  color: #848687;
-  font-family: PlusJakartaSans_600SemiBold;
-  font-size: 13px;
+  color: ${theme.colors.gray.gray_1};
+  ${({ theme }) => textStyle(theme.fonts.body.B5_SB)}
 `;
 
 const SpaceNameLengthText = styled.Text`
-  color: #cccfd0;
-  font-family: PlusJakartaSans_400Regular;
-  font-size: 13px;
+  color: ${theme.colors.gray.lightGray_1};
+  ${({ theme }) => textStyle(theme.fonts.body.B5_R)}
 `;
 
 const EnterSpaceNameContainer = styled.TextInput`
-  background-color: #353637;
+  background-color: ${theme.colors.gray.darkGray_1};
   height: 50px;
   padding-left: 10px;
   border-radius: 4px;
-  color: #ededed;
 `;
 
 const SpaceDecContainer = styled.View`
@@ -140,17 +137,15 @@ const SpaceDecContainer = styled.View`
 `;
 
 const SpaceDecText = styled.Text`
-  color: #848687;
-  font-family: PlusJakartaSans_600SemiBold;
-  font-size: 13px;
+  color: ${theme.colors.gray.gray_1};
+  ${({ theme }) => textStyle(theme.fonts.body.B5_SB)}
   margin-top: 10px;
 `;
 
 const EnterDecContainer = styled.View`
-  background-color: #353637;
+  background-color: ${theme.colors.gray.darkGray_1};
   height: 200px;
   border-radius: 4px;
-  color: #ededed;
   padding-left: 10px;
   position: relative;
   margin-top: 3px;
@@ -158,10 +153,8 @@ const EnterDecContainer = styled.View`
 
 const EnterDecInput = styled.TextInput`
   flex: 1;
-  color: #ededed;
-  font-size: 16px;
+  ${({ theme }) => textStyle(theme.fonts.body.B2_R)}
   line-height: 24px;
-  font-family: PlusJakartaSans_400Regular;
   text-align-vertical: top;
 `;
 
@@ -172,7 +165,6 @@ const LimitWrapper = styled.View`
 `;
 
 const LimitCount = styled.Text`
-  color: #848687;
-  font-size: 12px;
-  font-family: PlusJakartaSans_500Medium;
+  color: ${theme.colors.gray.gray_1};
+  ${({ theme }) => textStyle(theme.fonts.body.B5_M)}
 `;

--- a/src/features/linked-space/create/constants.ts
+++ b/src/features/linked-space/create/constants.ts
@@ -31,7 +31,7 @@ export const getDefaultAvatarUrl = (index: number): string => {
 /**
  * 스페이스 이름 최대 길이
  */
-export const SPACE_NAME_MAX_LENGTH = 20;
+export const SPACE_NAME_MAX_LENGTH = 30;
 
 /**
  * 스페이스 설명 최대 길이


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   constants에 잡힌 길이 제한을 20에서 30으로 수정하였습니다.
- theme 스타일을 적용하였습니다.

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #177 
