### PR TITLE
[Feat/#176] 채팅방 내부 복사하기 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "expo-auth-session": "~6.2.1",
         "expo-blur": "~14.1.5",
         "expo-build-properties": "~0.14.8",
+        "expo-clipboard": "~7.1.5",
         "expo-constants": "~17.1.7",
         "expo-crypto": "~14.1.5",
         "expo-dev-client": "~5.2.4",
@@ -9351,6 +9352,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.5.tgz",
+      "integrity": "sha512-TCANUGOxouoJXxKBW5ASJl2WlmQLGpuZGemDCL2fO5ZMl57DGTypUmagb0CVUFxDl0yAtFIcESd78UsF9o64aw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "expo-auth-session": "~6.2.1",
     "expo-blur": "~14.1.5",
     "expo-build-properties": "~0.14.8",
+    "expo-clipboard": "~7.1.5",
     "expo-constants": "~17.1.7",
     "expo-crypto": "~14.1.5",
     "expo-dev-client": "~5.2.4",

--- a/src/features/chat/room/components/message/HighlightText.tsx
+++ b/src/features/chat/room/components/message/HighlightText.tsx
@@ -1,4 +1,5 @@
 // 텍스트 내 키워드 하이라이트 컴포넌트
+import { theme } from '@/src/styles/theme';
 import React from 'react';
 import styled from 'styled-components/native';
 import { HighlightTextProps } from '../../types';
@@ -44,13 +45,11 @@ export default HighlightText;
 
 // ============= Styled Components =============
 const MyText = styled.Text`
-  color: #1d1e1f;
-  font-size: 14px;
-  font-family: PlusJakartaSans_400Regular;
+  color: ${theme.colors.primary.black};
+  ${({ theme }) => theme.fonts.body.B4_R}
 `;
 
 const OtherText = styled.Text`
-  color: #ffffff;
-  font-size: 14px;
-  font-family: PlusJakartaSans_300Light;
+  color: ${theme.colors.primary.white};
+  ${({ theme }) => theme.fonts.body.B4_L}
 `;

--- a/src/features/chat/room/components/message/MessageItem.tsx
+++ b/src/features/chat/room/components/message/MessageItem.tsx
@@ -50,7 +50,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ item, index, isMyMessage, onD
           content={messageContent}
           time={formatTime(item.sentAt)}
           showTime={displayLogic.showTime}
-          isFirst={!displayLogic.isSameUser}
+          isFirst={!displayLogic.isSameUserAbove}
           searchKeyword={shouldHighlight ? searchText : undefined}
           onLongPress={handleLongPress}
         />
@@ -63,7 +63,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ item, index, isMyMessage, onD
           senderImageUrl={item.senderImageUrl}
           showTime={displayLogic.showTime}
           showProfile={displayLogic.showProfile}
-          isFirst={!displayLogic.isSameUser}
+          isFirst={!displayLogic.isSameUserAbove}
           searchKeyword={shouldHighlight ? searchText : undefined}
           onProfilePress={() => onProfilePress(item.senderId)}
           onLongPress={handleLongPress}

--- a/src/features/chat/room/components/message/MessageItem.tsx
+++ b/src/features/chat/room/components/message/MessageItem.tsx
@@ -62,7 +62,7 @@ const MessageItem: React.FC<MessageItemProps> = ({ item, index, isMyMessage, onD
           senderName={item.senderFirstName + ' ' + item.senderLastName}
           senderImageUrl={item.senderImageUrl}
           showTime={displayLogic.showTime}
-          showProfile={displayLogic.showTime}
+          showProfile={displayLogic.showProfile}
           isFirst={!displayLogic.isSameUser}
           searchKeyword={shouldHighlight ? searchText : undefined}
           onProfilePress={() => onProfilePress(item.senderId)}

--- a/src/features/chat/room/components/message/MessageItem.tsx
+++ b/src/features/chat/room/components/message/MessageItem.tsx
@@ -1,11 +1,14 @@
 //MyMessageBubble과 OtherMessageBubble을 조합한 형태의 메시지 아이템 컴포넌트
 import { formatDate, formatTime } from '@/src/shared/utils/dateUtils';
-import React from 'react';
+import { theme } from '@/src/styles/theme';
+import React, { useRef, useState } from 'react';
+import { View } from 'react-native';
 import styled from 'styled-components/native';
 import { useChatStore } from '../../stores/useChatStore';
 import { useSearchStore } from '../../stores/useSearchStore';
 import { MessageItemProps } from '../../types';
 import { displayMessageItem } from '../../utils/displayMessageItem';
+import MessageMenu from './MessageMenu';
 import MyMessageBubble from './MyMessageBubble';
 import OtherMessageBubble from './OtherMessageBubble';
 
@@ -21,11 +24,14 @@ const MessageItem: React.FC<MessageItemProps> = ({
   const { isActive, searchResults, currentIndex, searchText } = useSearchStore();
   const isTranslating = useChatStore((state) => state.isTranslating);
 
-  // 메시지 표시 로직
-  const displayLogic = displayMessageItem(item, index, messages);
+  // 컨텍스트 메뉴 상태 관리
+  const [menuVisible, setMenuVisible] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
+  const [messageHeight, setMessageHeight] = useState(0);
+  const bubbleRef = useRef<View>(null);
 
-  // 날짜 구분선 표시 여부
-  const shouldShowDateSeparator = displayLogic.showDate;
+  // 날짜 및 시간 표시, 동일 사용자 판단
+  const displayLogic = displayMessageItem(item, index, messages);
 
   // 메시지 콘텐츠 (번역 여부에 따라)
   const messageContent = isTranslating ? item.targetContent : item.originContent;
@@ -33,20 +39,31 @@ const MessageItem: React.FC<MessageItemProps> = ({
   // 메시지 강조 표시 여부
   const shouldHighlight = isActive && searchResults.length > 0 && searchResults[currentIndex]?.id === item.id;
 
+  // 길게 누르기 핸들러
+  const handleLongPress = () => {
+    bubbleRef.current?.measure((x, y, width, height, pageX, pageY) => {
+      setMenuPosition({ x: pageX, y: pageY });
+      setMessageHeight(height);
+      setMenuVisible(true);
+    });
+  };
+
   return (
     <>
       {/* 메시지 */}
       {isMyMessage ? (
         <MyMessageBubble
+          ref={bubbleRef}
           content={messageContent}
           time={formatTime(item.sentAt)}
           showTime={displayLogic.showTime}
           isFirst={!displayLogic.isSameUser}
           searchKeyword={shouldHighlight ? searchText : undefined}
-          onLongPress={() => onDeleteMessage(item.id)}
+          onLongPress={handleLongPress}
         />
       ) : (
         <OtherMessageBubble
+          ref={bubbleRef}
           content={messageContent}
           time={formatTime(item.sentAt)}
           senderName={item.senderFirstName + ' ' + item.senderLastName}
@@ -56,40 +73,41 @@ const MessageItem: React.FC<MessageItemProps> = ({
           isFirst={!displayLogic.isSameUser}
           searchKeyword={shouldHighlight ? searchText : undefined}
           onProfilePress={() => onProfilePress(item.senderId)}
+          onLongPress={handleLongPress}
         />
       )}
 
       {/* 날짜 구분선 */}
-      {shouldShowDateSeparator && (
+      {displayLogic.showDate && (
         <DateSeparator>
           <DateText>{formatDate(item.sentAt)}</DateText>
         </DateSeparator>
       )}
+
+      {/* 컨텍스트 메뉴 */}
+      <MessageMenu
+        visible={menuVisible}
+        position={menuPosition}
+        messageHeight={messageHeight}
+        isMyMessage={isMyMessage}
+        content={messageContent}
+        onDelete={isMyMessage ? () => onDeleteMessage(item.id) : undefined}
+        onClose={() => setMenuVisible(false)}
+      />
     </>
   );
 };
 
 export default MessageItem;
 
-// ============= Constants =============
-const DATE_SEPARATOR_CONFIG = {
-  MARGIN_VERTICAL: 10,
-  MARGIN_BOTTOM: 10,
-  HEIGHT: 20,
-  FONT_SIZE: 12,
-  COLOR: '#848687',
-} as const;
-
 // ============= Styled Components =============
 const DateSeparator = styled.View`
-  margin: ${DATE_SEPARATOR_CONFIG.MARGIN_VERTICAL}px 0px ${DATE_SEPARATOR_CONFIG.MARGIN_BOTTOM}px 0px;
-  height: ${DATE_SEPARATOR_CONFIG.HEIGHT}px;
+  margin: 20px 0px;
   justify-content: center;
   align-items: center;
 `;
 
 const DateText = styled.Text`
-  color: ${DATE_SEPARATOR_CONFIG.COLOR};
-  font-size: ${DATE_SEPARATOR_CONFIG.FONT_SIZE}px;
-  font-family: PlusJakartaSans_600SemiBold;
+  color: ${theme.colors.gray.gray_1};
+  ${theme.fonts.small.small_SB};
 `;

--- a/src/features/chat/room/components/message/MessageItem.tsx
+++ b/src/features/chat/room/components/message/MessageItem.tsx
@@ -12,14 +12,7 @@ import MessageMenu from './MessageMenu';
 import MyMessageBubble from './MyMessageBubble';
 import OtherMessageBubble from './OtherMessageBubble';
 
-const MessageItem: React.FC<MessageItemProps> = ({
-  item,
-  index,
-  messages,
-  isMyMessage,
-  onDeleteMessage,
-  onProfilePress,
-}) => {
+const MessageItem: React.FC<MessageItemProps> = ({ item, index, isMyMessage, onDeleteMessage, onProfilePress }) => {
   // Store에서 직접 가져오기
   const { isActive, searchResults, currentIndex, searchText } = useSearchStore();
   const isTranslating = useChatStore((state) => state.isTranslating);
@@ -31,7 +24,7 @@ const MessageItem: React.FC<MessageItemProps> = ({
   const bubbleRef = useRef<View>(null);
 
   // 날짜 및 시간 표시, 동일 사용자 판단
-  const displayLogic = displayMessageItem(item, index, messages);
+  const displayLogic = displayMessageItem(item, index);
 
   // 메시지 콘텐츠 (번역 여부에 따라)
   const messageContent = isTranslating ? item.targetContent : item.originContent;

--- a/src/features/chat/room/components/message/MessageList.tsx
+++ b/src/features/chat/room/components/message/MessageList.tsx
@@ -18,7 +18,6 @@ const MessageList: React.FC<MessageListProps> = ({
     <MessageItem
       item={item}
       index={index}
-      messages={messages}
       isMyMessage={myUserId === item.senderId.toString()}
       onDeleteMessage={onDeleteMessage}
       onProfilePress={onProfilePress}

--- a/src/features/chat/room/components/message/MessageMenu.tsx
+++ b/src/features/chat/room/components/message/MessageMenu.tsx
@@ -24,7 +24,7 @@ const MessageMenu: React.FC<MessageMenuProps> = ({
   onDelete,
   onClose,
 }) => {
-  const scaleAnim = useRef(new Animated.Value(0.6)).current;
+  const scaleAnim = useRef(new Animated.Value(0.8)).current;
   const opacityAnim = useRef(new Animated.Value(0)).current;
 
   const handleCopy = async () => {

--- a/src/features/chat/room/components/message/MessageMenu.tsx
+++ b/src/features/chat/room/components/message/MessageMenu.tsx
@@ -1,0 +1,144 @@
+// 메시지 컨텍스트 메뉴 (길게 누르기 시 표시되는 팝업)
+import { theme } from '@/src/styles/theme';
+import * as Clipboard from 'expo-clipboard';
+import React, { useEffect, useRef } from 'react';
+import { Animated, Modal, TouchableWithoutFeedback } from 'react-native';
+import styled from 'styled-components/native';
+
+interface MessageMenuProps {
+  visible: boolean;
+  position: { x: number; y: number };
+  messageHeight: number;
+  isMyMessage: boolean;
+  content: string;
+  onDelete?: () => void;
+  onClose: () => void;
+}
+
+const MessageMenu: React.FC<MessageMenuProps> = ({
+  visible,
+  position,
+  messageHeight,
+  isMyMessage,
+  content,
+  onDelete,
+  onClose,
+}) => {
+  const scaleAnim = useRef(new Animated.Value(0.6)).current;
+  const opacityAnim = useRef(new Animated.Value(0)).current;
+
+  const handleCopy = async () => {
+    await Clipboard.setStringAsync(content);
+    onClose();
+  };
+
+  const handleDelete = () => {
+    if (onDelete) {
+      onDelete();
+    }
+    onClose();
+  };
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.spring(scaleAnim, {
+          toValue: 1,
+          useNativeDriver: true,
+          tension: 100,
+          friction: 8,
+        }),
+        Animated.timing(opacityAnim, {
+          toValue: 1,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else {
+      scaleAnim.setValue(0.8);
+      opacityAnim.setValue(0);
+    }
+  }, [visible, scaleAnim, opacityAnim]);
+
+  if (!visible) return null;
+
+  // 메뉴 위치 계산
+  const menuY =
+    position.y - (isMyMessage ? MENU_CONFIG.HEIGHT_WITH_DELETE : MENU_CONFIG.HEIGHT) - MENU_CONFIG.MARGIN_BOTTOM;
+  const showBelow = menuY < MENU_CONFIG.SAFE_MARGIN_TOP;
+
+  const finalY = showBelow ? position.y + messageHeight + MENU_CONFIG.MARGIN_TOP : menuY;
+
+  const menuStyle = {
+    top: finalY,
+    right: isMyMessage ? MENU_CONFIG.RIGHT_MARGIN : undefined,
+    left: isMyMessage ? undefined : position.x + MENU_CONFIG.LEFT_MARGIN,
+    transform: [{ scale: scaleAnim }],
+    opacity: opacityAnim,
+  };
+
+  return (
+    <Modal transparent visible={visible} animationType="none" onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <Overlay>
+          <MenuContainer style={menuStyle}>
+            <MenuItem onPress={handleCopy}>
+              <MenuText>Copy</MenuText>
+            </MenuItem>
+            {isMyMessage && onDelete && (
+              <>
+                <MenuItem onPress={handleDelete}>
+                  <DeleteText>Delete</DeleteText>
+                </MenuItem>
+              </>
+            )}
+          </MenuContainer>
+        </Overlay>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+export default MessageMenu;
+
+// ============= Constants =============
+const MENU_CONFIG = {
+  HEIGHT: 40, // 버튼 1개일 때
+  HEIGHT_WITH_DELETE: 105, // 버튼 2개일 때
+  WIDTH: 100,
+  MARGIN_BOTTOM: 8,
+  MARGIN_TOP: 8,
+  LEFT_MARGIN: 50, // 좌측 정렬 마진
+  RIGHT_MARGIN: 20, // 우측 정렬 마진
+  SAFE_MARGIN_TOP: 50, // 상단 안전 영역
+  BORDER_RADIUS: 12,
+  ITEM_HEIGHT: 42,
+} as const;
+
+// ============= Styled Components =============
+const Overlay = styled.View`
+  flex: 1;
+`;
+
+const MenuContainer = styled(Animated.View)`
+  position: absolute;
+  width: ${MENU_CONFIG.WIDTH}px;
+  background-color: ${theme.colors.primary.white};
+  border-radius: ${MENU_CONFIG.BORDER_RADIUS}px;
+`;
+
+const MenuItem = styled.TouchableOpacity`
+  height: ${MENU_CONFIG.ITEM_HEIGHT}px;
+  justify-content: center;
+  align-items: center;
+`;
+
+const MenuText = styled.Text`
+  ${theme.fonts.body.B4_M};
+  color: ${theme.colors.primary.black};
+`;
+
+const DeleteText = styled.Text`
+  ${theme.fonts.body.B4_M};
+  color: ${theme.colors.secondary.red};
+`;

--- a/src/features/chat/room/components/message/MyMessageBubble.tsx
+++ b/src/features/chat/room/components/message/MyMessageBubble.tsx
@@ -1,26 +1,22 @@
 // 나의 메시지 버블 컴포넌트(단일 메시지)
-import React from 'react';
+import React, { forwardRef } from 'react';
+import { View } from 'react-native';
 import styled from 'styled-components/native';
 import { MyMessageBubbleProps } from '../../types';
 import HighlightText from './HighlightText';
 
-const MyMessageBubble: React.FC<MyMessageBubbleProps> = ({
-  content,
-  time,
-  showTime,
-  isFirst,
-  searchKeyword,
-  onLongPress,
-}) => {
-  return (
-    <MessageContainer onLongPress={onLongPress}>
-      {showTime && <TimeText>{time}</TimeText>}
-      <BubbleContainer isFirst={isFirst}>
-        <HighlightText text={content} keyword={searchKeyword} textType="my" />
-      </BubbleContainer>
-    </MessageContainer>
-  );
-};
+const MyMessageBubble = forwardRef<View, MyMessageBubbleProps>(
+  ({ content, time, showTime, isFirst, searchKeyword, onLongPress }, ref) => {
+    return (
+      <MessageContainer ref={ref} onLongPress={onLongPress}>
+        {showTime && <TimeText>{time}</TimeText>}
+        <BubbleContainer isFirst={isFirst}>
+          <HighlightText text={content} keyword={searchKeyword} textType="my" />
+        </BubbleContainer>
+      </MessageContainer>
+    );
+  },
+);
 
 export default MyMessageBubble;
 

--- a/src/features/chat/room/components/message/OtherMessageBubble.tsx
+++ b/src/features/chat/room/components/message/OtherMessageBubble.tsx
@@ -1,45 +1,52 @@
 // 상대의 메시지 버블 컴포넌트(단일 메시지)
 import RawProfileImage from '@/components/common/ProfileImage';
-import React from 'react';
+import React, { forwardRef } from 'react';
+import { View } from 'react-native';
 import styled from 'styled-components/native';
 import { OtherMessageBubbleProps } from '../../types';
 import HighlightText from './HighlightText';
 
-const OtherMessageBubble: React.FC<OtherMessageBubbleProps> = ({
-  content,
-  time,
-  senderName,
-  senderImageUrl,
-  showTime,
-  showProfile,
-  isFirst,
-  searchKeyword,
-  onProfilePress,
-}) => {
-  return (
-    <MessageContainer showProfile={showProfile}>
-      <ProfileContainer>
-        {showProfile && (
-          <ProfileBox>
-            <ProfileButton onPress={onProfilePress}>
-              <ProfileImg source={{ uri: senderImageUrl }} />
-            </ProfileButton>
-          </ProfileBox>
-        )}
-      </ProfileContainer>
+const OtherMessageBubble = forwardRef<View, OtherMessageBubbleProps>(
+  (
+    {
+      content,
+      time,
+      senderName,
+      senderImageUrl,
+      showTime,
+      showProfile,
+      isFirst,
+      searchKeyword,
+      onProfilePress,
+      onLongPress,
+    },
+    ref,
+  ) => {
+    return (
+      <MessageContainer ref={ref} showProfile={showProfile} onLongPress={onLongPress}>
+        <ProfileContainer>
+          {showProfile && (
+            <ProfileBox>
+              <ProfileButton onPress={onProfilePress}>
+                <ProfileImg source={{ uri: senderImageUrl }} />
+              </ProfileButton>
+            </ProfileBox>
+          )}
+        </ProfileContainer>
 
-      <ContentContainer>
-        {showProfile && <SenderNameText>{senderName}</SenderNameText>}
-        <MessageBox>
-          <BubbleContainer isFirst={isFirst}>
-            <HighlightText text={content} keyword={searchKeyword || ''} textType="other" />
-          </BubbleContainer>
-          {showTime && <TimeText>{time}</TimeText>}
-        </MessageBox>
-      </ContentContainer>
-    </MessageContainer>
-  );
-};
+        <ContentContainer>
+          {showProfile && <SenderNameText>{senderName}</SenderNameText>}
+          <MessageBox>
+            <BubbleContainer isFirst={isFirst}>
+              <HighlightText text={content} keyword={searchKeyword || ''} textType="other" />
+            </BubbleContainer>
+            {showTime && <TimeText>{time}</TimeText>}
+          </MessageBox>
+        </ContentContainer>
+      </MessageContainer>
+    );
+  },
+);
 
 export default OtherMessageBubble;
 
@@ -58,7 +65,6 @@ const OTHER_MESSAGE_CONFIG = {
   TIME_COLOR: '#848687',
   NAME_COLOR: '#ffffff',
   MARGIN_TOP_FIRST: 20,
-  MARGIN_TOP_REGULAR: 1,
   MESSAGE_BOX_MARGIN_TOP: 5,
   TIME_MARGIN_LEFT: 3,
   TIME_FONT_SIZE: 10,
@@ -85,8 +91,7 @@ const BaseBubble = styled.View`
 
 // ============= Styled Components =============
 const MessageContainer = styled(BaseContainer)<{ showProfile?: boolean }>`
-  margin-top: ${({ showProfile }) =>
-    showProfile ? OTHER_MESSAGE_CONFIG.MARGIN_TOP_FIRST : OTHER_MESSAGE_CONFIG.MARGIN_TOP_REGULAR}px;
+  margin-top: ${({ showProfile }) => (showProfile ? OTHER_MESSAGE_CONFIG.MARGIN_TOP_FIRST : 0)}px;
 `;
 
 const ProfileContainer = styled.View`

--- a/src/features/chat/room/types/index.ts
+++ b/src/features/chat/room/types/index.ts
@@ -26,6 +26,7 @@ export interface OtherMessageBubbleProps extends BaseMessageProps {
   senderImageUrl: string;
   isFirst: boolean;
   onProfilePress: () => void;
+  onLongPress: () => void;
 }
 
 export interface MessageItemProps {

--- a/src/features/chat/room/types/index.ts
+++ b/src/features/chat/room/types/index.ts
@@ -32,7 +32,6 @@ export interface OtherMessageBubbleProps extends BaseMessageProps {
 export interface MessageItemProps {
   item: ChatMessage;
   index: number;
-  messages: ChatMessage[];
   isMyMessage: boolean;
   onDeleteMessage: (id: number) => void;
   onProfilePress: (senderId: number) => void;

--- a/src/features/chat/room/utils/displayMessageItem.ts
+++ b/src/features/chat/room/utils/displayMessageItem.ts
@@ -2,25 +2,48 @@ import { formatDate, formatTime } from '@/src/shared/utils/dateUtils';
 import { useChatStore } from '../stores/useChatStore';
 import { ChatMessage } from '../types/index';
 
+/** 메시지 Info 표시 로직 */
 export const displayMessageItem = (currentMessage: ChatMessage, index: number) => {
   const messages = useChatStore.getState().messages;
   // 메시지 순서: [0, 1, 2, ..., n] (0이 최신 메시지)
 
-  /** 상단 메시지와 같은 사용자인지 확인
-   * @return 이전 메시지와 같은 사용자 여부
-   */
-  const isSameUser =
+  /** 상단 메시지와 같은 사용자인지 확인 */
+  const isSameUserAbove =
     index < messages.length - 1 && messages[index + 1].senderFirstName === messages[index].senderFirstName;
 
-  /** 시간 표시 여부 */
-  const showTime =
-    index === 0 || // 가장 최신 메시지인 경우
-    (index < messages.length - 1 &&
-      formatTime(messages[index + 1].sentAt) !== formatTime(messages[index].sentAt) &&
-      isSameUser) || // 이전 메시지와 시간이 다른 경우
-    !isSameUser; // 이전 메시지와 사용자가 다른 경우
+  /** 하단 메시지와 같은 사용자인지 확인 */
+  const isSameUserBelow = index > 0 && messages[index - 1].senderFirstName === messages[index].senderFirstName;
 
-  const showProfile = !isSameUser || showTime;
+  /** 상단 메시지와 같은 시간인지 확인 */
+  const isSameTimeAbove =
+    index < messages.length - 1 && formatTime(messages[index + 1].sentAt) === formatTime(messages[index].sentAt);
+
+  /** 하단 메시지와 같은 시간인지 확인 */
+  const isSameTimeBelow = index > 0 && formatTime(messages[index - 1].sentAt) === formatTime(messages[index].sentAt);
+
+  /** 메시지 연속성 여부 */
+  const isMessageContinuous = isSameUserAbove && isSameTimeAbove && isSameUserBelow && isSameTimeBelow;
+
+  /** 시간 표시 여부 (메시지 연속성 고려) */
+  const showTime =
+    // 메시지가 연속되지 않는 경우
+    // !isMessageContinuous ||
+
+    // 하단이 다른 사용자인 경우(최하단 메시지 포함)
+    !isSameUserBelow ||
+    // 하단이 같은 사용자이지만 시간이 연속되지 않는 경우
+    (isSameUserBelow && !isSameTimeBelow) ||
+    // 상단이 다른 사용자이고 하단의 시간이 연속되지 않을 때(최상단 메시지 포함)
+    (!isSameUserAbove && !isSameTimeBelow);
+
+  /** 프로필 표시 여부 */
+  const showProfile =
+    // 첫 메시지이거나
+    index === messages.length - 1 ||
+    // 상단 메시지와 다른 사용자이거나
+    !isSameUserAbove ||
+    // 같은 사용자이지만 시간이 연속되지 않는 경우
+    (isSameUserAbove && !isSameTimeAbove);
 
   /** 날짜 표시 여부 */
   const showDate =
@@ -31,6 +54,6 @@ export const displayMessageItem = (currentMessage: ChatMessage, index: number) =
     showTime,
     showDate,
     showProfile,
-    isSameUser,
+    isSameUserAbove,
   };
 };

--- a/src/features/chat/room/utils/displayMessageItem.ts
+++ b/src/features/chat/room/utils/displayMessageItem.ts
@@ -14,11 +14,13 @@ export const displayMessageItem = (currentMessage: ChatMessage, index: number) =
 
   /** 시간 표시 여부 */
   const showTime =
-    index === 0 ||
+    index === 0 || // 가장 최신 메시지인 경우
     (index < messages.length - 1 &&
       formatTime(messages[index + 1].sentAt) !== formatTime(messages[index].sentAt) &&
-      isSameUser) ||
-    !isSameUser;
+      isSameUser) || // 이전 메시지와 시간이 다른 경우
+    !isSameUser; // 이전 메시지와 사용자가 다른 경우
+
+  const showProfile = !isSameUser || showTime;
 
   /** 날짜 표시 여부 */
   const showDate =
@@ -28,6 +30,7 @@ export const displayMessageItem = (currentMessage: ChatMessage, index: number) =
   return {
     showTime,
     showDate,
+    showProfile,
     isSameUser,
   };
 };

--- a/src/features/chat/room/utils/displayMessageItem.ts
+++ b/src/features/chat/room/utils/displayMessageItem.ts
@@ -1,6 +1,9 @@
 import { formatDate, formatTime } from '@/src/shared/utils/dateUtils';
+import { useChatStore } from '../stores/useChatStore';
+import { ChatMessage } from '../types/index';
 
-export const displayMessageItem = (currentMessage: any, index: number, messages: any[]) => {
+export const displayMessageItem = (currentMessage: ChatMessage, index: number) => {
+  const messages = useChatStore.getState().messages;
   // 메시지 순서: [0, 1, 2, ..., n] (0이 최신 메시지)
 
   /** 상단 메시지와 같은 사용자인지 확인

--- a/src/features/chat/room/utils/displayMessageItem.ts
+++ b/src/features/chat/room/utils/displayMessageItem.ts
@@ -21,14 +21,8 @@ export const displayMessageItem = (currentMessage: ChatMessage, index: number) =
   /** 하단 메시지와 같은 시간인지 확인 */
   const isSameTimeBelow = index > 0 && formatTime(messages[index - 1].sentAt) === formatTime(messages[index].sentAt);
 
-  /** 메시지 연속성 여부 */
-  const isMessageContinuous = isSameUserAbove && isSameTimeAbove && isSameUserBelow && isSameTimeBelow;
-
   /** 시간 표시 여부 (메시지 연속성 고려) */
   const showTime =
-    // 메시지가 연속되지 않는 경우
-    // !isMessageContinuous ||
-
     // 하단이 다른 사용자인 경우(최하단 메시지 포함)
     !isSameUserBelow ||
     // 하단이 같은 사용자이지만 시간이 연속되지 않는 경우


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   메시지 길게 클릭 시 메뉴창 팝업
- 메뉴창에 복사하기 및 삭제 기능 구현

## 🔍 작업 상세 내용

### 메시지 메뉴 컴포넌트
- 메시지를 길게 눌렀을 때의 행동이 확장 될 수 있음을 고려하여 새로운 컴포넌트를 생성하고 적용했습니다.
- 다만 상세 디자인이 없기에 스타일은 임의로 진행한 점 참고 바랍니다.
- 메시지를 길게 눌렀을 때 해당 메시지 상단에 메뉴를 표시하기 위해 ref와 내장함수(mersure)를 사용하였고
- 해당 x, y, height 값과 특정 픽셀값을 계산하여 메뉴 컴포넌트가 좌측 혹은 우측에 정렬되도록 하였습니다.
```typescript
//src\features\chat\room\components\message\MessageItem.tsx
import { View } from 'react-native';
const bubbleRef = useRef<View>(null);

bubbleRef.current?.measure((x, y, width, height, pageX, pageY) => {
      setMenuPosition({ x: pageX, y: pageY });
      setMessageHeight(height);
      setMenuVisible(true);
});

// 위치 계산은 MessageMenu.tsx 내부에서 진행합니다.
```



### 복사 기능 
-  구현을 위해 ```expo-clipboard``` 라이브러리를 추가하였습니다.
❗ 해당 라이브러리는 네이티브 모듈이기 때문에 npm i 뿐만 아니라  **앱 재빌드가 필요합니다.**
#### 사용 예제
```typescript
import * as Clipboard from 'expo-clipboard';
...
await Clipboard.setStringAsync(복사하고자 하는 내용);
...
```

### 메시지 Info 로직 점검
- 이슈를 생성 한 뒤 새로이 pr을 올렸어야 했는데 그러지 못한 점 양해 부탁드립니다...ㅠ
- 작업 중에 채팅방 시간 표기가 의도와 달라 로직을 수정 및 점검했습니다. (최대한 카카오톡을 따라가고자 하였습니다.)
- 메시지 **시간은 하단 중심**, **프로필은 상단 중심**입니다.
- 시간의 다름 기준은 1분 입니다.

#### 시간
조건1. 메시지 하단이 다른 사용자인 경우
조건2. 메시지 하단이 같은 사용자이지만 시간이 연속되지 않는 경우
조건3. 메시지 상단이 다른 사용자이고 하단의 시간이 연속되지 않을 때

#### 프로필
조건1. 첫 메시지
조건2. 상단 메시지와 다른 사용자
조건3. 메시지 상단과 같은 사용자이지만 시간이 연속되지 않는 경우

##### 예시
```
//case 1: 시간이 다른 경우
사용자 A (00:00)  <<  프로필 o 시간 o
사용자 A (00:01)  <<  프로필 o 시간 o
사용자 B (00:02)  <<  프로필 o 시간 o
사용자 C (00:04)  <<  프로필 o 시간 o

//case 2: 같은 시간에 같은 사용자가 메시지를 n번 보낸 경우
사용자 A (00:05)  <<  프로필 o 시간 x
사용자 A (00:05)  <<  프로필 x 시간 x
사용자 A (00:05)  <<  프로필 x 시간 x
사용자 A (00:05)  <<  프로필 x 시간 o

//case 3: 다른 시간에 같은 사용자가 메시지를 n번 보낸 경우
사용자 A (00:06)  <<  프로필 o 시간 x
사용자 A (00:06)  <<  프로필 x 시간 o
사용자 A (00:07)  <<  프로필 o 시간 x
사용자 A (00:07)  <<  프로필 x 시간 x
사용자 A (00:07)  <<  프로필 x 시간 o
사용자 A (00:08)  <<  프로필 o 시간 x
사용자 A (00:08)  <<  프로필 x 시간 o
```



## 🏞️ 스크린샷
- 내 메시지를 길게 누를 시
<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/c7c42da6-0990-47a1-ba45-e11586e0dc1b" />

- 상대 메시지를 길게 누를 시
<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/768cfc0a-3544-40f7-9a01-0f428b8442ab" />


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #176 
