### PR TITLE
[Hotfix/#193] chat message bug

### DIFF
--- a/src/features/chat/room/hooks/useChatMessages.ts
+++ b/src/features/chat/room/hooks/useChatMessages.ts
@@ -22,11 +22,10 @@ export const useChatMessages = (roomId: string): ChatMessagesHook => {
   const addMessageToStore = useChatStore((state) => state.addMessage);
   const removeMessageFromStore = useChatStore((state) => state.removeMessage);
   const loadMoreMessagesToStore = useChatStore((state) => state.loadMoreMessages);
-  const setCurrentMessage = useChatStore((state) => state.setCurrentMessage);
   const setFetchingMore = useChatStore((state) => state.setFetchingMore);
   const setHasMore = useChatStore((state) => state.setHasMore);
+  const reset = useChatStore((state) => state.reset);
   const setError = useChatStore((state) => state.setError);
-  const clearMessagesInStore = useChatStore((state) => state.clearMessages);
 
   // Room 초기화 (컴포넌트 마운트 시)
   useEffect(() => {
@@ -40,9 +39,9 @@ export const useChatMessages = (roomId: string): ChatMessagesHook => {
     init();
 
     return () => {
-      useChatStore.getState().reset();
+      reset();
     };
-  }, [roomId, initialize]);
+  }, [roomId, initialize, reset]);
 
   /** 메시지 로드(+무한 스크롤) */
   const loadMessages = useCallback(async () => {

--- a/src/features/chat/room/stores/useChatStore.ts
+++ b/src/features/chat/room/stores/useChatStore.ts
@@ -26,7 +26,6 @@ interface ChatStoreState extends RoomMessagesState {
   setHasMore: (hasMore: boolean) => void;
 
   // 유틸리티
-  clearMessages: () => void;
   reset: () => void;
   setError: (error: Error | null) => void;
 
@@ -123,14 +122,6 @@ export const useChatStore = create<ChatStoreState>()(
     setHasMore: (hasMore: boolean) => {
       set((state) => {
         state.hasMore = hasMore;
-      });
-    },
-
-    // 메시지 목록 초기화
-    clearMessages: () => {
-      set((state) => {
-        state.messages = [];
-        state.hasMore = true;
       });
     },
 

--- a/src/features/chat/shared/hooks/useUserProfile.ts
+++ b/src/features/chat/shared/hooks/useUserProfile.ts
@@ -134,8 +134,9 @@ export const useUserProfile = (): UserProfileHook => {
       closeProfile();
 
       // 새 채팅방으로 이동
-      router.push({
+      router.replace({
         pathname: CHAT_ROUTE(roomId),
+        params: { roomName: encodeURIComponent(selectedUser.firstname + ' ' + selectedUser.lastname) },
       });
     } catch (error) {
       console.error('채팅방 생성 실패:', error);

--- a/src/features/chat/shared/hooks/useUserProfileQuery.ts
+++ b/src/features/chat/shared/hooks/useUserProfileQuery.ts
@@ -1,3 +1,4 @@
+import { CHAT_ROOMS_QUERY_KEY } from '@/src/features/chat/list/hooks/useChatRooms';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createOneToOneRoom, fetchUserProfile, followUser, unfollowUser } from '../api';
 
@@ -47,7 +48,11 @@ export const useUnfollowUserMutation = () => {
 
 /** 1:1 채팅방 생성 Mutation */
 export const useCreateOneToOneRoomMutation = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createOneToOneRoom,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CHAT_ROOMS_QUERY_KEY });
+    },
   });
 };

--- a/src/features/chat/shared/type.ts
+++ b/src/features/chat/shared/type.ts
@@ -5,8 +5,8 @@ export type FollowStatus = 'FOLLOWING' | 'PENDING' | 'NOT_FOLLOWING';
 export interface UserProfileData {
   userId: number;
   id?: number;
-  firstName: string;
-  lastName: string;
+  firstname: string;
+  lastname: string;
   gender: string;
   birthday: number;
   introduction: string;

--- a/src/features/linked-space/create/hooks/useCreateSpace.ts
+++ b/src/features/linked-space/create/hooks/useCreateSpace.ts
@@ -1,5 +1,7 @@
+import { CHAT_ROOMS_QUERY_KEY } from '@/src/features/chat/list/hooks/useChatRooms';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
+import { ALL_SPACES_QUERY_KEY, BUZZING_SPACES_QUERY_KEY } from '../../list/hooks/useLinkedSpaceRooms';
 import { createGroupSpace } from '../api/spaceApi';
 import { getDefaultAvatarUrl } from '../constants';
 import { CreateSpaceFormData } from '../types';
@@ -38,9 +40,9 @@ export const useCreateSpace = () => {
     },
     onSuccess: () => {
       // 채팅방 목록 쿼리들을 무효화하여 최신 데이터 refetch
-      queryClient.invalidateQueries({ queryKey: ['chatRooms'] });
-      queryClient.invalidateQueries({ queryKey: ['buzzingSpaces'] });
-      queryClient.invalidateQueries({ queryKey: ['allSpaces'] });
+      queryClient.invalidateQueries({ queryKey: CHAT_ROOMS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: BUZZING_SPACES_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ALL_SPACES_QUERY_KEY });
     },
     onError: (error: Error) => {
       Toast.show({

--- a/src/features/linked-space/list/hooks/useLinkedSpaceRooms.ts
+++ b/src/features/linked-space/list/hooks/useLinkedSpaceRooms.ts
@@ -2,16 +2,19 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { fetchAllSpaces, fetchBuzzingSpaces } from '../api/linkedSpace';
 import { LinkedSpace } from '../types';
 
+export const BUZZING_SPACES_QUERY_KEY = ['buzzingSpaces'];
+export const ALL_SPACES_QUERY_KEY = ['allSpaces'];
+
 export const useBuzzingSpaces = () => {
   return useQuery<LinkedSpace[]>({
-    queryKey: ['buzzingSpaces'],
+    queryKey: BUZZING_SPACES_QUERY_KEY,
     queryFn: fetchBuzzingSpaces,
   });
 };
 
 export const useAllSpaces = () => {
   return useInfiniteQuery<LinkedSpace[]>({
-    queryKey: ['allSpaces'],
+    queryKey: ALL_SPACES_QUERY_KEY,
     queryFn: ({ pageParam }) => fetchAllSpaces(pageParam as number | null),
     initialPageParam: null,
     getNextPageParam: (lastPage) => {


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   채팅방 생성 시 최근 채팅방 메시지가 노출되던 문제를 수정하였습니다.

## 🔍 작업 상세 내용
-   기존의 채팅방 이동 로직을 router.push에서 router.replace로 수정하였습니다.
    - router.push의 경우 컴포넌트가 화면 위에 덧대어져서 상태 혹은 메모리가 중복으로 관리되는 듯 합니다.
    - 예를 들어 A (그룹)채팅방에서 B (개인)채팅방으로 push 이동을 하게 되면 A 채팅방 상태가 초기화 되지 않고 B 채팅방으로 이동하여 A 채팅방 메시지가 그대로 노출되는 문제가 발생합니다. (해당 예시의 경우 B 채팅방에서 모바일 좌 -> 우 슬라이드 시 채팅 목록이 아닌 A 채팅방 노출)
    - 따라서 채팅방 이동 route 사용시 가급적 replace 사용을 권장(채팅방 내부에 뒤로가기 버튼 존재) 드리며 
    **params에 roomName 또한 전달해야 합니다**
    ```typescript
      import { CHAT_ROUTE } from '@/src/shared/constants/route';
      ...
      router.replace({
        pathname: CHAT_ROUTE(roomId),
        params: { roomName: roomName || 유저의 firstname + ' ' + lastname 조합 },
      });
    ```
- export 기반으로 쿼리 키를 관리할 수 있도록 수정하였습니다.


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #193 
