### PR TITLE
[hotfix/#212] oauth 로그인 시 중복 이메일 에러 핸들링

### DIFF
--- a/src/features/auth/components/SignInButtonWrapper.tsx
+++ b/src/features/auth/components/SignInButtonWrapper.tsx
@@ -51,7 +51,7 @@ function SignInButtonWrapper({ onSuccessSocialSignIn }: SignInButtonWrapperProps
         Toast.show({
           type: 'error',
           text1: errorConfig.message,
-          text2: 'Please try again later.',
+          text2: errorConfig.subMessage || 'Please try again later.',
         });
       }
     }

--- a/src/features/auth/constants/error.ts
+++ b/src/features/auth/constants/error.ts
@@ -26,10 +26,12 @@ const COMMON_AUTH_ERROR: ErrorConfig = {
   EMAIL_ALREADY_REGISTERED: {
     httpStatus: 409,
     message: 'The email is already registered with another account.',
+    subMessage: 'Please check your email address.',
   },
   DUPLICATE_EMAIL_PROVIDER_MISMATCH: {
     httpStatus: 409,
     message: 'Already registered with another social account.',
+    subMessage: 'Please check your email address.',
   },
 };
 

--- a/src/features/auth/constants/error.ts
+++ b/src/features/auth/constants/error.ts
@@ -31,7 +31,7 @@ const COMMON_AUTH_ERROR: ErrorConfig = {
   DUPLICATE_EMAIL_PROVIDER_MISMATCH: {
     httpStatus: 409,
     message: 'Already registered with another social account.',
-    subMessage: 'Please check your email address.',
+    subMessage: 'Please sign in with your existing account.',
   },
 };
 

--- a/src/features/auth/constants/error.ts
+++ b/src/features/auth/constants/error.ts
@@ -27,6 +27,10 @@ const COMMON_AUTH_ERROR: ErrorConfig = {
     httpStatus: 409,
     message: 'The email is already registered with another account.',
   },
+  DUPLICATE_EMAIL_PROVIDER_MISMATCH: {
+    httpStatus: 409,
+    message: 'Already registered with another social account.',
+  },
 };
 
 // 애플 소셜 로그인 에러

--- a/src/shared/types/error.ts
+++ b/src/shared/types/error.ts
@@ -1,1 +1,1 @@
-export type ErrorConfig = Record<string, { message: string; code?: string; httpStatus?: number }>;
+export type ErrorConfig = Record<string, { message: string; code?: string; httpStatus?: number; subMessage?: string }>;


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

oauth 로그인 시 발생하는 중복 이메일 가입 에러 핸들링을 구현했습니다.

현재 제 안드로이드 에뮬레이터에서 구글 로그인이 안 되고 있어서 구글 로그인은 아직 테스트하지 못했습니다.
시간 되실 때 안드로이드 환경에서 테스트 한 번씩만 부탁드립니다!
> ❗️ **테스트 방법**
>
> 1️⃣ 구글 이메일 주소로 **`이메일 회원가입`**
> 2️⃣ 회원가입 및 프로필 셋업 후 로그아웃
> 3️⃣ 1️⃣과 동일한 이메일 주소로 **`구글 소셜 로그인`**
> 4️⃣ Toast로 에러 메시지가 잘 뜨는지 확인

## 🔍 작업 상세 내용

**1. 중복 이메일 가입 error constant를 추가했습니다.**

oauth 로그인 시, 이미 해당 계정으로 가입한 회원이 존재할 경우 발생하는 에러에 대한 constant를 추가했습니다.
```ts
  DUPLICATE_EMAIL_PROVIDER_MISMATCH: {
    httpStatus: 409,
    message: 'Already registered with another social account.',
    ...
  },
```
<br/>

**2. error constant에 subMessage 필드를 추가해 Toast에서 보여줄 수 있도록 수정했습니다.**

error type 및 constant에 message 필드 외에 추가적인 안내 메시지를 설정할 수 있는 `subMessage` 필드를 추가했습니다.
여기에는 에러에 관한 추가적인 정보 및 사용자가 어떤 행동을 취해야 에러를 피할 수 있는지에 대한 간략한 정보를 작성할 수 있습니다.
```ts
export type ErrorConfig = Record<string, { message: string; code?: string; httpStatus?: number; subMessage?: string }>;
```
> subMessage 필드를 선택사항으로 추가

```ts
  DUPLICATE_EMAIL_PROVIDER_MISMATCH: {
    httpStatus: 409,
    message: 'Already registered with another social account.',
    subMessage: 'Please check your email address.', // 필요 시 subMessage 작성
  },
```
> subMessage를 통해 이메일 주소를 확인해달라는 추가적인 정보를 제공

`Toast.show` 호출 시 `text2` 필드에 `subMessage`를 전달하면 해당 정보도 토스트 내부에 함께 노출됩니다.

```ts
// 사용자가 로그인을 취소한 경우를 제외하고 error toast 표시
      if (errorConfig !== APPLE_AUTH_ERROR.ERR_REQUEST_CANCELED) {
        Toast.show({
          type: 'error',
          text1: errorConfig.message,
          text2: errorConfig.subMessage || 'Please try again later.', // subMessage 및 fallback text 지정
        });
      }
```


## 🏞️ 스크린샷

<img width="300" height="1278" alt="IMG_5806" src="https://github.com/user-attachments/assets/96ea1ff1-2410-4f00-88b1-1d8668ae2634" />

> 중복 이메일로 가입 시도 시 Toast 노출

## ✅ 체크리스트

-   [x] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [x] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [x] 불필요한 console.log, 주석을 제거했나요?
-   [x] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #212
