### PR TITLE
[Fix/#219] chat 멤버 모달 수정

### DIFF
--- a/app/chat/[roomId]/members/index.tsx
+++ b/app/chat/[roomId]/members/index.tsx
@@ -61,26 +61,23 @@ const ChatInsideMember = () => {
 
         {/* Report/Block Modal */}
         <ReportBlockModal
-          visible={reportBlock.isModalVisible}
+          bottomSheetRef={reportBlock.reportBlockSheetRef}
           targetUserName={reportBlock.selectedMemberName || ''}
-          onClose={reportBlock.closeModal}
           onPressBlock={reportBlock.handleBlockUser}
-          onPressReport={reportBlock.openReportMenu}
+          onPressReport={reportBlock.openReportReasonSheet}
         />
 
         {/* Report Reason Modal */}
         <ReportReasonModal
-          visible={reportBlock.isReportMenuVisible}
-          onClose={reportBlock.closeReportMenuModal}
+          bottomSheetRef={reportBlock.reportReasonSheetRef}
           onSelectReason={(reason: ReportReason) => {
-            reportBlock.openReportDetailModal();
+            reportBlock.openReportDetailSheet();
           }}
         />
 
         {/* Report Detail Modal */}
         <ReportDetailModal
-          visible={reportBlock.isReportVisible}
-          onClose={reportBlock.closeReportDetailModal}
+          bottomSheetRef={reportBlock.reportDetailSheetRef}
           onSubmit={reportBlock.handleSubmitReport}
         />
       </Container>

--- a/src/features/chat/list/components/MyChatList.tsx
+++ b/src/features/chat/list/components/MyChatList.tsx
@@ -8,7 +8,6 @@ import { MyChatRoom } from '../types';
 
 export const MyChatList = ({ data }: { data: MyChatRoom }) => {
   const router = useRouter();
-  console.info(data);
 
   //채팅방 진입
   const enterChattingRoom = async () => {

--- a/src/features/chat/member/components/ReportBlockModal.tsx
+++ b/src/features/chat/member/components/ReportBlockModal.tsx
@@ -1,40 +1,45 @@
+import CustomBottomSheet from '@/src/shared/components/CustomBottomSheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import React from 'react';
 import styled from 'styled-components/native';
-import { BottomSheetBase } from './BottomSheetBase';
 
 interface ReportBlockModalProps {
-  visible: boolean;
+  bottomSheetRef: React.RefObject<BottomSheetModal | null>;
   targetUserName: string;
-  onClose: () => void;
   onPressBlock: () => void;
   onPressReport: () => void;
 }
 
 /**
  * 신고/차단 선택 모달
- * BottomSheetBase를 활용한 첫 번째 단계 모달
+ * CustomBottomSheet를 활용한 첫 번째 단계 모달
  */
 export const ReportBlockModal: React.FC<ReportBlockModalProps> = ({
-  visible,
+  bottomSheetRef,
   targetUserName,
-  onClose,
   onPressBlock,
   onPressReport,
 }) => {
   return (
-    <BottomSheetBase visible={visible} onClose={onClose}>
-      <TargetUser>{targetUserName}</TargetUser>
+    <CustomBottomSheet ref={bottomSheetRef}>
+      <Container>
+        <TargetUser>{targetUserName}</TargetUser>
 
-      <MenuItem onPress={onPressReport}>
-        <MenuText>Report</MenuText>
-      </MenuItem>
+        <MenuItem onPress={onPressReport}>
+          <MenuText>Report</MenuText>
+        </MenuItem>
 
-      <MenuItem onPress={onPressBlock}>
-        <MenuText style={{ color: '#FF4F4F' }}>Block</MenuText>
-      </MenuItem>
-    </BottomSheetBase>
+        <MenuItem onPress={onPressBlock}>
+          <MenuText style={{ color: '#FF4F4F' }}>Block</MenuText>
+        </MenuItem>
+      </Container>
+    </CustomBottomSheet>
   );
 };
+
+const Container = styled.View`
+  padding: 20px 0px 40px 0px;
+`;
 
 const TargetUser = styled.Text`
   color: #ffffff;

--- a/src/features/chat/member/components/ReportDetailModal.tsx
+++ b/src/features/chat/member/components/ReportDetailModal.tsx
@@ -1,18 +1,18 @@
+import CustomBottomSheet from '@/src/shared/components/CustomBottomSheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import React, { useState } from 'react';
-import { Modal } from 'react-native';
 import styled from 'styled-components/native';
 
 interface ReportDetailModalProps {
-  visible: boolean;
-  onClose: () => void;
+  bottomSheetRef: React.RefObject<BottomSheetModal | null>;
   onSubmit: (details: string) => void;
 }
 
 /**
  * 신고 상세 내용 입력 모달
- * 독립적인 Modal 구조 (BottomSheetBase 미사용)
+ * CustomBottomSheet를 활용한 세 번째 단계 모달
  */
-export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({ visible, onClose, onSubmit }) => {
+export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({ bottomSheetRef, onSubmit }) => {
   const [details, setDetails] = useState('');
 
   const handleSubmit = () => {
@@ -21,46 +21,33 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({ visible, o
   };
 
   return (
-    <Modal visible={visible} transparent animationType="slide">
-      <ModalOverlay activeOpacity={1} onPress={onClose}>
-        <ModalContent onStartShouldSetResponder={() => true}>
-          <ModalTitle>Provide Additional Details (Optional)</ModalTitle>
+    <CustomBottomSheet ref={bottomSheetRef}>
+      <Container>
+        <ModalTitle>Provide Additional Details (Optional)</ModalTitle>
 
-          <ModalSubTitle>Help us understand what's happening</ModalSubTitle>
+        <ModalSubTitle>Help us understand what's happening</ModalSubTitle>
 
-          <TextInput
-            multiline
-            placeholder="Share additional details..."
-            placeholderTextColor="#949899"
-            value={details}
-            onChangeText={setDetails}
-            maxLength={500}
-          />
+        <TextInput
+          multiline
+          placeholder="Share additional details..."
+          placeholderTextColor="#949899"
+          value={details}
+          onChangeText={setDetails}
+          maxLength={500}
+        />
 
-          <CharCount>{details.length}/500</CharCount>
+        <CharCount>{details.length}/500</CharCount>
 
-          <SubmitButton onPress={handleSubmit}>
-            <SubmitButtonText>Submit Report</SubmitButtonText>
-          </SubmitButton>
-        </ModalContent>
-      </ModalOverlay>
-    </Modal>
+        <SubmitButton onPress={handleSubmit}>
+          <SubmitButtonText>Submit Report</SubmitButtonText>
+        </SubmitButton>
+      </Container>
+    </CustomBottomSheet>
   );
 };
 
-const ModalOverlay = styled.TouchableOpacity`
-  flex: 1;
-  background-color: rgba(0, 0, 0, 0.5);
-  justify-content: center;
-  align-items: center;
-`;
-
-const ModalContent = styled.View`
-  background-color: #353637;
-  border-radius: 12px;
-  padding: 24px;
-  width: 90%;
-  max-width: 400px;
+const Container = styled.View`
+  padding: 20px 20px 40px 20px;
 `;
 
 const ModalTitle = styled.Text`

--- a/src/features/chat/member/components/ReportReasonModal.tsx
+++ b/src/features/chat/member/components/ReportReasonModal.tsx
@@ -1,11 +1,11 @@
+import CustomBottomSheet from '@/src/shared/components/CustomBottomSheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import React from 'react';
 import styled from 'styled-components/native';
 import type { ReportReason } from '../types';
-import { BottomSheetBase } from './BottomSheetBase';
 
 interface ReportReasonModalProps {
-  visible: boolean;
-  onClose: () => void;
+  bottomSheetRef: React.RefObject<BottomSheetModal | null>;
   onSelectReason: (reason: ReportReason) => void;
 }
 
@@ -19,21 +19,27 @@ const REPORT_REASONS: Array<{ label: string; value: ReportReason }> = [
 
 /**
  * 신고 사유 선택 모달
- * BottomSheetBase를 활용한 두 번째 단계 모달
+ * CustomBottomSheet를 활용한 두 번째 단계 모달
  */
-export const ReportReasonModal: React.FC<ReportReasonModalProps> = ({ visible, onClose, onSelectReason }) => {
+export const ReportReasonModal: React.FC<ReportReasonModalProps> = ({ bottomSheetRef, onSelectReason }) => {
   return (
-    <BottomSheetBase visible={visible} onClose={onClose}>
-      <ModalTitle>Why are you reporting this?</ModalTitle>
+    <CustomBottomSheet ref={bottomSheetRef}>
+      <Container>
+        <ModalTitle>Why are you reporting this?</ModalTitle>
 
-      {REPORT_REASONS.map((reason) => (
-        <MenuItem key={reason.value} onPress={() => onSelectReason(reason.value)}>
-          <MenuText>{reason.label}</MenuText>
-        </MenuItem>
-      ))}
-    </BottomSheetBase>
+        {REPORT_REASONS.map((reason) => (
+          <MenuItem key={reason.value} onPress={() => onSelectReason(reason.value)}>
+            <MenuText>{reason.label}</MenuText>
+          </MenuItem>
+        ))}
+      </Container>
+    </CustomBottomSheet>
   );
 };
+
+const Container = styled.View`
+  padding: 20px 0px 40px 0px;
+`;
 
 const ModalTitle = styled.Text`
   color: #ffffff;

--- a/src/features/chat/member/hooks/useReportBlock.ts
+++ b/src/features/chat/member/hooks/useReportBlock.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { blockUser, checkIsGroupChat } from '../api';
@@ -10,88 +11,82 @@ interface UseReportBlockParams {
 }
 
 interface UseReportBlockReturn {
-  // 모달 상태
-  isModalVisible: boolean;
-  isReportMenuVisible: boolean;
-  isReportVisible: boolean;
+  // BottomSheet Refs
+  reportBlockSheetRef: React.RefObject<BottomSheetModal | null>;
+  reportReasonSheetRef: React.RefObject<BottomSheetModal | null>;
+  reportDetailSheetRef: React.RefObject<BottomSheetModal | null>;
 
   // 선택된 사용자 정보
   selectedMemberName: string | null;
   targetUserId: number | null;
 
-  // 신고 내용
-  reportDetails: string;
-  setReportDetails: (text: string) => void;
-
   // 모달 제어
   openReportBlockMenu: (userId: number, memberName: string) => void;
-  closeModal: () => void;
-  openReportMenu: () => void;
-  closeReportMenuModal: () => void;
-  openReportDetailModal: () => void;
-  closeReportDetailModal: () => void;
+  closeReportBlockSheet: () => void;
+  openReportReasonSheet: () => void;
+  closeReportReasonSheet: () => void;
+  openReportDetailSheet: () => void;
+  closeReportDetailSheet: () => void;
 
   // 액션
   handleBlockUser: () => void;
-  handleSubmitReport: () => Promise<void>;
+  handleSubmitReport: (details: string) => Promise<void>;
 }
 
 /**
  * 신고/차단 및 관련 모달 관리 Hook
  */
 export const useReportBlock = ({ roomId, onLeaveChat }: UseReportBlockParams): UseReportBlockReturn => {
-  // 모달 상태
-  const [isModalVisible, setModalVisible] = useState(false);
-  const [isReportMenuVisible, setReportMenuVisible] = useState(false);
-  const [isReportVisible, setIsReportVisible] = useState(false);
+  // BottomSheet Refs
+  const reportBlockSheetRef = useRef<BottomSheetModal | null>(null);
+  const reportReasonSheetRef = useRef<BottomSheetModal | null>(null);
+  const reportDetailSheetRef = useRef<BottomSheetModal | null>(null);
 
   // 선택된 사용자 정보
   const [selectedMemberName, setSelectedMemberName] = useState<string | null>(null);
   const [targetUserId, setTargetUserId] = useState<number | null>(null);
 
-  // 신고 내용
-  const [reportDetails, setReportDetails] = useState('');
-
   // 신고/차단 메뉴 열기
   const openReportBlockMenu = (userId: number, memberName: string) => {
     setSelectedMemberName(memberName);
     setTargetUserId(userId);
-    setModalVisible(true);
+    reportBlockSheetRef.current?.present();
   };
 
   // 신고/차단 메뉴 닫기
-  const closeModal = () => {
-    setModalVisible(false);
+  const closeReportBlockSheet = () => {
+    reportBlockSheetRef.current?.dismiss();
   };
 
   // 신고 사유 선택 메뉴 열기
-  const openReportMenu = () => {
-    setModalVisible(false);
-    setReportMenuVisible(true);
+  const openReportReasonSheet = () => {
+    closeReportBlockSheet();
+    setTimeout(() => {
+      reportReasonSheetRef.current?.present();
+    }, 300);
   };
 
   // 신고 사유 선택 메뉴 닫기
-  const closeReportMenuModal = () => {
-    setReportMenuVisible(false);
-    setModalVisible(false);
+  const closeReportReasonSheet = () => {
+    reportReasonSheetRef.current?.dismiss();
   };
 
   // 신고 상세 입력 모달 열기
-  const openReportDetailModal = () => {
-    setModalVisible(false);
-    setReportMenuVisible(false);
-    setIsReportVisible(true);
+  const openReportDetailSheet = () => {
+    closeReportReasonSheet();
+    setTimeout(() => {
+      reportDetailSheetRef.current?.present();
+    }, 300);
   };
 
   // 신고 상세 입력 모달 닫기
-  const closeReportDetailModal = () => {
-    setIsReportVisible(false);
-    setReportDetails('');
+  const closeReportDetailSheet = () => {
+    reportDetailSheetRef.current?.dismiss();
   };
 
   // 차단하기
   const handleBlockUser = () => {
-    setModalVisible(false);
+    closeReportBlockSheet();
 
     Alert.alert(
       'Block User',
@@ -140,12 +135,12 @@ export const useReportBlock = ({ roomId, onLeaveChat }: UseReportBlockParams): U
   };
 
   // 신고 제출
-  const handleSubmitReport = async () => {
+  const handleSubmitReport = async (details: string) => {
     if (!targetUserId) return;
 
     try {
       // TODO: API 스펙 확인 후 주석 해제
-      // await reportUser(targetUserId, reportDetails);
+      // await reportUser(targetUserId, details);
 
       Toast.show({
         type: 'success',
@@ -153,7 +148,7 @@ export const useReportBlock = ({ roomId, onLeaveChat }: UseReportBlockParams): U
         text2: 'It takes up to 24 hours to review',
       });
 
-      closeReportDetailModal();
+      closeReportDetailSheet();
       setTargetUserId(null);
       setSelectedMemberName(null);
     } catch (error) {
@@ -162,31 +157,27 @@ export const useReportBlock = ({ roomId, onLeaveChat }: UseReportBlockParams): U
         type: 'error',
         text1: 'Report Fail',
       });
-      closeReportDetailModal();
+      closeReportDetailSheet();
     }
   };
 
   return {
-    // 모달 상태
-    isModalVisible,
-    isReportMenuVisible,
-    isReportVisible,
+    // BottomSheet Refs
+    reportBlockSheetRef,
+    reportReasonSheetRef,
+    reportDetailSheetRef,
 
     // 선택된 사용자 정보
     selectedMemberName,
     targetUserId,
 
-    // 신고 내용
-    reportDetails,
-    setReportDetails,
-
     // 모달 제어
     openReportBlockMenu,
-    closeModal,
-    openReportMenu,
-    closeReportMenuModal,
-    openReportDetailModal,
-    closeReportDetailModal,
+    closeReportBlockSheet,
+    openReportReasonSheet,
+    closeReportReasonSheet,
+    openReportDetailSheet,
+    closeReportDetailSheet,
 
     // 액션
     handleBlockUser,

--- a/src/features/chat/room/components/header/ChatHeader.tsx
+++ b/src/features/chat/room/components/header/ChatHeader.tsx
@@ -17,7 +17,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({ roomName, onShowMembers, onSear
       <TranslateTooltip visible={showTooltip} onConfirm={handleConfirm} onCancel={handleCancel} />
 
       <LeftSection>
-        <TouchableOpacity onPress={() => router.replace('/(tabs)/chat')}>
+        <TouchableOpacity onPress={() => router.back()}>
           <Icon type="previous" size={HEADER_CONFIG.ICON_SIZE} />
         </TouchableOpacity>
       </LeftSection>


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   채팅 멤버 확인 페이지에서 각 멤버별 우측 점 3개 클릭 시 나타나는 모달에 대해 공통 바텀시트를 적용하였습니다
 
## 🔍 작업 상세 내용

### 공통 바텀시트 적용
-   ReportBlockModal(신고/차단 선택 모달)
- ReportReasonModal(신고 사유 선택 모달)
- ReportDetailModal(신고 상세 내용 입력 모달)

위 3개 모달에 대해서 공통 바텀 시트를 적용하는 것으로 검은 뒷 배경이 함께 아래에서 위로 올라오는 문제를 해결하였습니다.

### ETC
- 채팅방 목록 컴포넌트에 작성된 console.info 문을 제거하였습니다.
- 채팅방 헤더에 뒤로가기 표시를 눌렀을 때의 동작을 router.replace에서 router.back으로 수정하였습니다.
  - replace는 히스토리를 완전 비우고 해당 주소로 대체하지만 채팅방 입장 시 push로 이동하였기 때문에 back을 사용하여 채팅방 들어오기 이전 화면이 나타나도록 했습니다.
  - 해당 작업을 통해 채팅방에서 뒤로가기를 실행 시 linked space가 나타나지 않고 my chat이 나타나게 됩니다.

## 🏞️ 스크린샷

-   스크린샷이 있다면 첨부해주세요.

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

Closes #219 
