### PR TITLE
[fix/#243] 자동 로그인 로직 수정

### DIFF
--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -19,8 +19,6 @@ function shortUrl(base: string, url?: string) {
 export const doRefresh = async (): Promise<string | null> => {
   const rt = await SecureStore.getItemAsync(REFRESH_KEY);
   if (!rt) {
-    // 리프레시 토큰이 없을 경우 남아있을 수 있는 Authorization 헤더 제거
-    delete (api.defaults.headers as any).Authorization;
     return null;
   }
 
@@ -33,17 +31,12 @@ export const doRefresh = async (): Promise<string | null> => {
     if (newAt) {
       await SecureStore.setItemAsync(ACCESS_KEY, newAt);
       (api.defaults.headers as any).Authorization = `Bearer ${newAt}`;
-      redirectingToAuth = false;
     }
     if (newRt) {
       await SecureStore.setItemAsync(REFRESH_KEY, newRt);
     }
     return newAt ?? null;
   } catch {
-    // 리프레시 실패 시 저장된 토큰과 헤더를 정리해 이후 요청에서 만료된 토큰이 다시 실리지 않도록 함
-    await SecureStore.deleteItemAsync(ACCESS_KEY).catch(() => {});
-    await SecureStore.deleteItemAsync(REFRESH_KEY).catch(() => {});
-    delete (api.defaults.headers as any).Authorization;
     return null;
   }
 };
@@ -55,7 +48,6 @@ const api: AxiosInstance = axios.create({
 });
 
 let refreshPromise: Promise<string | null> | null = null;
-let redirectingToAuth = false;
 
 api.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
@@ -135,12 +127,8 @@ api.interceptors.response.use(
         // 토큰이 없으면 서버에 요청 보내지 말고, 로그인 화면으로 보내기
         await SecureStore.deleteItemAsync(ACCESS_KEY);
         await SecureStore.deleteItemAsync(REFRESH_KEY);
-        delete (api.defaults.headers as any).Authorization;
 
-        if (!redirectingToAuth) {
-          redirectingToAuth = true; // 중복 리다이렉트 방지
-          router.replace('/(auth)');
-        }
+        router.replace('/(auth)');
 
         return Promise.reject(error);
       }

--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -18,7 +18,11 @@ function shortUrl(base: string, url?: string) {
 
 export const doRefresh = async (): Promise<string | null> => {
   const rt = await SecureStore.getItemAsync(REFRESH_KEY);
-  if (!rt) return null;
+  if (!rt) {
+    // 리프레시 토큰이 없을 경우 남아있을 수 있는 Authorization 헤더 제거
+    delete (api.defaults.headers as any).Authorization;
+    return null;
+  }
 
   try {
     const res = await api.post('/api/v1/member/refresh', { refreshToken: rt });
@@ -29,12 +33,17 @@ export const doRefresh = async (): Promise<string | null> => {
     if (newAt) {
       await SecureStore.setItemAsync(ACCESS_KEY, newAt);
       (api.defaults.headers as any).Authorization = `Bearer ${newAt}`;
+      redirectingToAuth = false;
     }
     if (newRt) {
       await SecureStore.setItemAsync(REFRESH_KEY, newRt);
     }
     return newAt ?? null;
   } catch {
+    // 리프레시 실패 시 저장된 토큰과 헤더를 정리해 이후 요청에서 만료된 토큰이 다시 실리지 않도록 함
+    await SecureStore.deleteItemAsync(ACCESS_KEY).catch(() => {});
+    await SecureStore.deleteItemAsync(REFRESH_KEY).catch(() => {});
+    delete (api.defaults.headers as any).Authorization;
     return null;
   }
 };
@@ -46,6 +55,7 @@ const api: AxiosInstance = axios.create({
 });
 
 let refreshPromise: Promise<string | null> | null = null;
+let redirectingToAuth = false;
 
 api.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
@@ -125,8 +135,12 @@ api.interceptors.response.use(
         // 토큰이 없으면 서버에 요청 보내지 말고, 로그인 화면으로 보내기
         await SecureStore.deleteItemAsync(ACCESS_KEY);
         await SecureStore.deleteItemAsync(REFRESH_KEY);
+        delete (api.defaults.headers as any).Authorization;
 
-        router.replace('/(auth)');
+        if (!redirectingToAuth) {
+          redirectingToAuth = true; // 중복 리다이렉트 방지
+          router.replace('/(auth)');
+        }
 
         return Promise.reject(error);
       }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -115,9 +115,9 @@ export default function RootLayout() {
                   </Stack>
                   <Toast config={toastConfig} topOffset={80} />
                 </ProfileProvider>
-                {/* 커뮤니티 관련 모달 - 전역에서 사용 */}
-                <MoreBottomSheet />
-                <ReportModal />
+                {/* 커뮤니티 관련 모달 - 전역에서 사용, 로그인 상태에 따라 조건부 렌더링*/}
+                {isLoggedIn && <MoreBottomSheet />}
+                {isLoggedIn && <ReportModal />}
               </AppLayout>
             </BottomSheetModalProvider>
           </SafeAreaProvider>

--- a/src/features/auth/hooks/useAutoLogin.ts
+++ b/src/features/auth/hooks/useAutoLogin.ts
@@ -7,13 +7,8 @@ export function useAutoLogin(isFontLoaded: boolean) {
 
   const autoLogin = useCallback(async () => {
     try {
-      const accessToken = doRefresh(); // 백그라운드에서 토큰 갱신 시도
-      if (!accessToken) {
-        setIsLoggedIn(false);
-        return;
-      }
-
-      setIsLoggedIn(true);
+      const accessToken = await doRefresh(); // 토큰 갱신 시도
+      setIsLoggedIn(!!accessToken);
     } catch (error) {
       console.error('자동 로그인 실패:', error);
       setIsLoggedIn(false);


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

자동 로그인 로직을 의도에 맞게 수정했습니다.

## 🔍 작업 상세 내용

**1. useAuthLogin에서 doRefresh를 호출 시 await 추가**

기존 코드는 `useAuthLogin` 에서 `doRefresh`를 await하지 않아 로직이 실행되지 않고 _layout.tsx의 라우팅이 바로 메인 페이지로 이동했습니다.
따라서 doRefresh()를 await하고 결과 토큰의 유무로 isLoggedIn을 설정하도록 수정했습니다.
이제 스플래시가 토큰 갱신 완료까지 유지되고, 실제 갱신 성공 여부에 따라 로그인 페이지 혹은 메인 페이지로 이동합니다.

~**2. axiosInstance에서 리프레시 토큰 갱신 시 기존 토큰 제거**~
> ~`doRefresh` 로직 실행 시, 리프레시 토큰이 없을 경우 남아 있을 수 있는 Authorization header를 제거하도록 수정했습니다.~
> ~doRefresh 로직이 실패할 경우, 저장되어 있던 토큰을 정리해 이후 요청에서 만료된 토큰이 실리지 않도록 수정했습니다.~
 
~**3. axiosInstance에서 로그인 페이지로 router replace 시 플래그 변수 추가**~
> ~로그인 페이지로 replace 여부를 결정하는 플래그 변수 `redirectingToAuth`를 추가했습니다.~
> ~이제 `redirectingToAuth`가 true일 때만 로그인 페이지로 이동하며, 로그인 페이지가 중복으로 라우팅되지 않습니다.~

**2. `app/_layout.tsx` 내의 커뮤니티 전역 모달을 로그인 여부에 따라 조건부 렌더링**

`app/_layout.tsx` 내의 커뮤니티 전역 모달에서 호출하던 프로필 셋업 완료 여부 api로 인해 로그인 화면에서도 401 에러가 발생하면서 로그인 페이지가 두 번 push되는 문제가 발생했습니다.
커뮤니티 전역 모달을 isLoggedIn 상태에 따라 조건부 렌더링하도록 코드를 변경해 로그인 화면에서는 api가 호출되지 않도록 수정했으며, 이제 로그인 페이지가 중복으로 push되지 않습니다.

## 🏞️ 스크린샷

- X

## ✅ 체크리스트

-   [x] 빌드가 실패 없이 완료되었나요?
-   [x] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [x] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [x] 불필요한 console.log, 주석을 제거했나요?
-   [x] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #243
