### PR TITLE
fix: 공통 바텀시트에 시스템 bottom값 추가

### DIFF
--- a/src/shared/components/CustomBottomSheet.tsx
+++ b/src/shared/components/CustomBottomSheet.tsx
@@ -1,6 +1,7 @@
 import { theme } from '@/src/styles/theme';
 import { BottomSheetBackdrop, BottomSheetBackdropProps, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import React, { ReactElement, useCallback } from 'react';
+import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface CustomBottomSheetProps {
@@ -38,7 +39,7 @@ const CustomBottomSheet = ({
   const bottomSheetViewStyle = {
     flex: 1,
     backgroundColor: backgroundColor,
-    paddingBottom: bottom,
+    paddingBottom: Platform.OS === 'android' ? bottom : 0,
   } as const;
 
   return (

--- a/src/shared/components/CustomBottomSheet.tsx
+++ b/src/shared/components/CustomBottomSheet.tsx
@@ -1,16 +1,8 @@
 import { theme } from '@/src/styles/theme';
 import { BottomSheetBackdrop, BottomSheetBackdropProps, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import React, { ReactElement, useCallback } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-/**
- * 공용 커스텀 바텀시트 컴포넌트
- * - 바텀시트 모달의 스타일과 백드롭을 공통으로 설정하고, 내부에 children을 렌더링합니다.
- * - children에 원하는 형태의 컴포넌트를 넣어 사용할 수 있습니다.
- *
- * @param children 바텀시트 내부에 렌더링할 컴포넌트
- * @param ref 바텀시트 모달 참조
- * @param onChange 바텀시트 인덱스 변경 시 호출되는 콜백 함수
- */
 interface CustomBottomSheetProps {
   children: ReactElement;
   ref: React.RefObject<BottomSheetModal | null>;
@@ -26,6 +18,8 @@ const CustomBottomSheet = ({
   backgroundColor = theme.colors.gray.darkGray_1,
   handleComponent = () => null,
 }: CustomBottomSheetProps) => {
+  const { bottom } = useSafeAreaInsets();
+
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.6} pressBehavior="close" />
@@ -41,7 +35,11 @@ const CustomBottomSheet = ({
     backgroundColor: backgroundColor,
   } as const;
 
-  const bottomSheetViewStyle = { flex: 1, backgroundColor: backgroundColor } as const;
+  const bottomSheetViewStyle = {
+    flex: 1,
+    backgroundColor: backgroundColor,
+    paddingBottom: bottom,
+  } as const;
 
   return (
     <BottomSheetModal
@@ -50,7 +48,7 @@ const CustomBottomSheet = ({
       backgroundStyle={bottomSheetModalStyle}
       handleIndicatorStyle={bottomSheetHandleStyle}
       backdropComponent={renderBackdrop}
-      handleComponent={handleComponent} // 핸들 숨기기
+      handleComponent={handleComponent}
     >
       <BottomSheetView style={bottomSheetViewStyle}>{children}</BottomSheetView>
     </BottomSheetModal>

--- a/src/shared/components/CustomBottomSheet.tsx
+++ b/src/shared/components/CustomBottomSheet.tsx
@@ -20,6 +20,7 @@ const CustomBottomSheet = ({
   handleComponent = () => null,
 }: CustomBottomSheetProps) => {
   const { bottom } = useSafeAreaInsets();
+  const isAndroidButtonNav = Platform.OS === 'android' && bottom > 25;
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -39,7 +40,7 @@ const CustomBottomSheet = ({
   const bottomSheetViewStyle = {
     flex: 1,
     backgroundColor: backgroundColor,
-    paddingBottom: Platform.OS === 'android' ? bottom : 0,
+    paddingBottom: isAndroidButtonNav ? bottom : 0,
   } as const;
 
   return (


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   공통 바텀시트(CustomBottomSheet)에 시스템 bottom값 만큼 padding을 추가하였습니다.

## 🔍 작업 상세 내용
- 기존 package.json에 있는 ```react-native-safe-area-context```를 사용하여 시스템 네비게이션(안드로이드의 경우 갤럭시 하단 네비게이션 바)의 높이 값을 padding에 더해줬습니다.

## 🏞️ 스크린샷
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/99ccff41-e78a-4b09-b8dc-335f356fdd42" />


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #181 
