### PR TITLE
[Bug/#199] linked space created

### DIFF
--- a/app/chat/create/index.tsx
+++ b/app/chat/create/index.tsx
@@ -9,14 +9,13 @@ import { CreateSpaceFormData } from '@/src/features/linked-space/create/types';
 import { theme } from '@/src/styles/theme';
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { KeyboardAvoidingView, Platform, StatusBar, TouchableOpacity } from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Platform, StatusBar, TouchableOpacity } from 'react-native';
 import styled from 'styled-components/native';
 
 const CreateSpaceScreen = () => {
   const [spaceName, setSpaceName] = useState('');
   const [description, setDescription] = useState('');
   const [showSuccess, setShowSuccess] = useState(false);
-  const [finalImageUrl, setFinalImageUrl] = useState<string>();
   const router = useRouter();
 
   // 이미지 선택 Hook
@@ -29,15 +28,12 @@ const CreateSpaceScreen = () => {
     const formData: CreateSpaceFormData = {
       spaceName,
       description,
-      imageUrl: imagePicker.avatarUrl,
-      imageUri: imagePicker.customPhotoUri,
-      isCustomImage: imagePicker.selectedAvatarIdx === -1,
+      customPhotoUri: imagePicker.customPhotoUri,
       avatarIndex: imagePicker.selectedAvatarIdx,
     };
 
     createSpaceMutation.mutate(formData, {
-      onSuccess: (data) => {
-        setFinalImageUrl(data.finalImageUrl);
+      onSuccess: () => {
         setShowSuccess(true);
       },
     });
@@ -49,7 +45,13 @@ const CreateSpaceScreen = () => {
 
   // 성공 화면 렌더링
   if (showSuccess) {
-    return <CreateSpaceSuccess spaceImageUrl={finalImageUrl} onDone={handleDone} />;
+    return (
+      <CreateSpaceSuccess
+        spaceImageUrl={imagePicker.customPhotoUri}
+        avatarIndex={imagePicker.selectedAvatarIdx}
+        onDone={handleDone}
+      />
+    );
   }
 
   // 폼 화면 렌더링
@@ -63,7 +65,7 @@ const CreateSpaceScreen = () => {
           </TouchableOpacity>
           <HeaderTitleText>Create Space</HeaderTitleText>
           <TouchableOpacity onPress={handleSave} disabled={createSpaceMutation.isPending}>
-            <SaveText>Save</SaveText>
+            {createSpaceMutation.isPending ? <ActivityIndicator color="#02f59b" /> : <SaveText>Save</SaveText>}
           </TouchableOpacity>
         </HeaderContainer>
 

--- a/src/features/linked-space/create/components/CreateSpaceSuccess.tsx
+++ b/src/features/linked-space/create/components/CreateSpaceSuccess.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import styled from 'styled-components/native';
+import { getDefaultAvatarSource } from '../constants';
 
 interface CreateSpaceSuccessProps {
   spaceImageUrl?: string;
+  avatarIndex: number;
   onDone: () => void;
 }
 
 /**
  * 스페이스 생성 성공 화면
  */
-export const CreateSpaceSuccess: React.FC<CreateSpaceSuccessProps> = ({ spaceImageUrl, onDone }) => {
+export const CreateSpaceSuccess: React.FC<CreateSpaceSuccessProps> = ({ spaceImageUrl, avatarIndex, onDone }) => {
   return (
     <Background source={require('@/assets/images/background2.png')} resizeMode="cover">
       <ProfileBox>
-        <ProfileImage source={{ uri: spaceImageUrl }} />
+        <ProfileImage source={spaceImageUrl ? { uri: spaceImageUrl } : getDefaultAvatarSource(avatarIndex)} />
       </ProfileBox>
 
       <TextBox>

--- a/src/features/linked-space/create/constants.ts
+++ b/src/features/linked-space/create/constants.ts
@@ -1,3 +1,4 @@
+import { ImageSourcePropType } from 'react-native';
 import { DefaultAvatar } from './types';
 
 /**
@@ -26,6 +27,16 @@ export const getDefaultAvatarUrl = (index: number): string => {
     return DEFAULT_AVATARS[index].url;
   }
   return DEFAULT_AVATARS[0].url;
+};
+
+/**
+ * 기본 아바타 인덱스로 소스 가져오기
+ */
+export const getDefaultAvatarSource = (index: number): ImageSourcePropType => {
+  if (index >= 0 && index < DEFAULT_AVATARS.length) {
+    return DEFAULT_AVATARS[index].source;
+  }
+  return DEFAULT_AVATARS[0].source;
 };
 
 /**

--- a/src/features/linked-space/create/hooks/useCreateSpace.ts
+++ b/src/features/linked-space/create/hooks/useCreateSpace.ts
@@ -18,9 +18,9 @@ export const useCreateSpace = () => {
       let finalImageUrl: string;
 
       // 커스텀 이미지인 경우 업로드
-      if (formData.isCustomImage && formData.imageUri) {
+      if (formData.customPhotoUri) {
         try {
-          finalImageUrl = await uploadCustomSpaceImage(formData.imageUri);
+          finalImageUrl = await uploadCustomSpaceImage(formData.customPhotoUri);
         } catch (error) {
           throw new Error('Image upload failed');
         }
@@ -36,7 +36,7 @@ export const useCreateSpace = () => {
         roomImageUrl: finalImageUrl,
       });
 
-      return { ...response, finalImageUrl };
+      return { ...response };
     },
     onSuccess: () => {
       // 채팅방 목록 쿼리들을 무효화하여 최신 데이터 refetch

--- a/src/features/linked-space/create/types.ts
+++ b/src/features/linked-space/create/types.ts
@@ -7,8 +7,7 @@ export interface CreateSpaceFormData {
   spaceName: string;
   description: string;
   imageUrl?: string;
-  imageUri?: string; // 로컬 URI (커스텀 이미지인 경우)
-  isCustomImage: boolean; // 커스텀 이미지 여부
+  customPhotoUri?: string;
   avatarIndex: number; // -1: 커스텀, 0-2: 기본 아바타
 }
 


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   링크드 스페이스 생성 완료 페이지에서 뜨지 않던 이미지가 뜰 수 있도록 수정하였습니다.

## 🔍 작업 상세 내용

-   formdata에 중복으로 관리되던 imageUrl 변수를 수정하였습니다.

<이미지 업로드 시>
링크드 스페이스 생성을 완료하면 이미지 미리보기로 관리되는 상태를 완료 페이지에 props로 넘겨 렌더링 되도록 수정했습니다.

<이미지 미 업로드, 기본 아바타 이미지 선택 시>
선택된 아바타 index를 완료 페이지에 props로 넘겨 해당하는 아바타의 이미지 파일을 렌더링 되도록 수정하였습니다.

- 추가로 이미지 업로드 후 링크드 스페이스 생성 시도 시 persignedUrl 발급으로 인해 생성 완료에 대한 지연이 발생하여 Save 버튼과 동일한 위치에 로딩 스피너를 추가하였습니다.

## 🏞️ 스크린샷
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/1ce774fa-bbc2-4c94-9548-e4fd09f14c5d" />


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #199 
