### PR TITLE
[fix/#254] ui 변경 및 인원 수 조정

### DIFF
--- a/src/features/linked-space/detail/components/ParticipantsInfo.tsx
+++ b/src/features/linked-space/detail/components/ParticipantsInfo.tsx
@@ -36,12 +36,16 @@ export const ParticipantsInfo = ({ participantCount, participantsImageUrls }: Pa
             showsHorizontalScrollIndicator={false}
             renderItem={({ item }) => (
               <ParticipantsImageBox>
-                <ProfileImage source={{ uri: item }} style={{ width: '100%', height: '100%' }} resizeMode="contain" />
+                <ProfileImage
+                  source={{ uri: item }}
+                  style={{ width: '100%', height: '100%', borderRadius: 100 }}
+                  resizeMode="contain"
+                />
               </ParticipantsImageBox>
             )}
           />
         </ParticipantsImagesBox>
-        <ParticipantsTotalText>+{participantCount}</ParticipantsTotalText>
+        <ParticipantsTotalText>+{participantCount - 5}</ParticipantsTotalText>
       </ParticipantsImageContainer>
     </ParticipantsContainer>
   );


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   링크드 스페이스 detail 페이지에서 멤버 이미지를 네모 ui에서 동그라미로 수정
- 멤버 이미지 우측 +인원 수를 -5로 조정

## 🏞️ 스크린샷
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/79f431b6-31a8-4831-bb8f-dd8ee5877083" />


## 🔗 관련 이슈

Closes #254 
