### PR TITLE
[Hotfix/#238] 메시지 흔들림 현상

### DIFF
--- a/src/features/chat/room/components/message/MessageList.tsx
+++ b/src/features/chat/room/components/message/MessageList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { FlatList } from 'react-native';
 import styled from 'styled-components/native';
 import { useChatStore } from '../../stores/useChatStore';
@@ -14,6 +14,8 @@ const MessageList: React.FC<MessageListProps> = ({
   flatListRef,
 }) => {
   const messages = useChatStore((state) => state.messages);
+  const [maintainPosition, setMaintainPosition] = useState(false);
+
   const renderMessage = ({ item, index }: { item: ChatMessage; index: number }) => (
     <MessageItem
       item={item}
@@ -29,8 +31,15 @@ const MessageList: React.FC<MessageListProps> = ({
       <FlatList
         ref={flatListRef}
         data={messages}
-        keyExtractor={(item, index) => `${item.id}-${index}`}
+        keyExtractor={(item) => item.id.toString()}
         inverted
+        // 스크롤 이벤트로 사용자가 위로 스크롤 중인지 감지
+        onScroll={useCallback((e: { nativeEvent: { contentOffset: { y: number } } }) => {
+          const y = e.nativeEvent.contentOffset.y;
+          // inverted FlatList 기준: y > threshold면 사용자가 위(이전 메시지)를 보고 있음
+          setMaintainPosition(y > 20);
+        }, [])}
+        scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={LIST_CONFIG.CONTENT_CONTAINER_STYLE}
         onEndReached={onLoadMore}
@@ -40,6 +49,8 @@ const MessageList: React.FC<MessageListProps> = ({
         maxToRenderPerBatch={LIST_CONFIG.MAX_TO_RENDER_PER_BATCH}
         windowSize={LIST_CONFIG.WINDOW_SIZE}
         getItemLayout={LIST_CONFIG.GET_ITEM_LAYOUT}
+        // 사용자가 위로 스크롤해 있을 때만 위치 유지 적용
+        maintainVisibleContentPosition={maintainPosition ? { minIndexForVisible: 0 } : undefined}
       />
     </ListContainer>
   );

--- a/src/features/chat/room/stores/useChatStore.ts
+++ b/src/features/chat/room/stores/useChatStore.ts
@@ -58,7 +58,7 @@ export const useChatStore = create<ChatStoreState>()(
     // 메시지 추가 (실시간)
     addMessage: (message: ChatMessage) => {
       set((state) => {
-        state.messages.unshift(message);
+        state.messages = [message, ...state.messages];
       });
     },
 


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-  채팅방을 상단으로 끌어 올렸을 때 해당 채팅방에 새로운 메시지가 수신되면 메시지 말풍선 렌더링에 오류가 일어나던 이슈를 수정하였습니다.

## 🔍 작업 상세 내용
#### [ 문제 요약 ]
- 증상: 채팅 목록을 위로 스크롤해 이전 메시지를 보고 있는 상태에서 실시간으로 새 메시지가 수신되면 말풍선들이 위아래로 흔들림(스크롤 위치가 유지되지 않음).
- 원인: inverted FlatList에서 항목을 prepend(또는 key가 불안정)하면 리스트 레이아웃/인덱스가 바뀌어 스크롤 위치가 밀리거나 재계산됨.

#### [ 해결책 요약 ]
- keyExtractor는 항상 안정적인 id만 사용(인덱스 제거).
- 메시지 렌더링을 관리하는 FlatList에 스크롤 이벤트 감지를 추가하여 사용자가 위로 스크롤 시 메시지 아이템의 변화가 일어나도 스크롤 위치를 유지할 수 있도록 하였습니다.
- 사용자가 “위로 보고 있을 때(이전 메시지 열람 중)”에만 maintainVisibleContentPosition을 활성화 — onScroll로 판별해 조건부 전달.
- 상태 업데이트는 불변성 유지(참조 안정화) 방식으로 새 배열 할당([new, ...old]) — 직접 mutate(unshift 등) 피함.
- scrollEventThrottle은 onScroll 반응성 제어용(작을수록 더 자주 호출) — 필요에 따라 값 조정.

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #238 
