### PR TITLE
[feat/#259] 번역 버튼 컴포넌트 추가

### DIFF
--- a/app/chat/[roomId]/index.tsx
+++ b/app/chat/[roomId]/index.tsx
@@ -4,6 +4,7 @@ import Header from '@/src/features/chat/room/components/header/Header';
 import MessageInput from '@/src/features/chat/room/components/input/MessageInput';
 import MessageList from '@/src/features/chat/room/components/message/MessageList';
 import SearchNavigation from '@/src/features/chat/room/components/search/SearchNavigation';
+import TranslateButton from '@/src/features/chat/room/components/TranslateButton';
 import { useChatMessages } from '@/src/features/chat/room/hooks/useChatMessages';
 import { useMessageActions } from '@/src/features/chat/room/hooks/useMessageActions';
 import { useMessageSearch } from '@/src/features/chat/room/hooks/useMessageSearch';
@@ -95,8 +96,7 @@ const ChattingRoomScreen = () => {
             {/* 프로필 모달 */}
             <ProfileModal visible={profileVisible} userData={selectedUser} onClose={() => setProfileVisible(false)} />
 
-            {/* 번역 버튼 추후 변경 혹은 삭제 예정 */}
-            {/* <TranslateButton /> */}
+            <TranslateButton />
           </ChattingScreen>
         </KeyboardAvoidingView>
       </Container>

--- a/src/features/chat/room/components/TranslateButton.tsx
+++ b/src/features/chat/room/components/TranslateButton.tsx
@@ -21,11 +21,11 @@ const TranslateButton = () => {
     );
   }
 
-  return (
-    <TranslateButtonBox onPress={onToggle} position="fixed">
-      <TranslateImage source={require('@/assets/images/translate.png')} />
-    </TranslateButtonBox>
-  );
+  return null;
+  // 떠다니는 번역 버튼
+  // <TranslateButtonBox onPress={onToggle} position="fixed">
+  //   <TranslateImage source={require('@/assets/images/translate.png')} />
+  // </TranslateButtonBox>
 };
 
 export default TranslateButton;


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요
-   이전에 사용하던 상단 번역 버튼 말풍선을 되돌려 놓았습니다.
    - 말풍선 클릭 시 말풍선만 제외되도록 하는 것으로 의논이 되었지만 기능이 off 되는 것으로 해야 우측 상단 버튼의 시인성이 높아지는 것 같아서 말풍선 클릭 시 기능 off도 같이 진행되도록 했습니다. @lixxce5017 

## 🏞️ 스크린샷
<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/135f3d90-b9fd-4e13-a373-74a4256f75c8" />

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #259 
