### PR TITLE
[Bug/#229] 채팅방 간 이동 시 메시지 중복 렌더링 수정 및 내비게이션 최적화

### DIFF
--- a/app/chat/[roomId]/index.tsx
+++ b/app/chat/[roomId]/index.tsx
@@ -93,7 +93,12 @@ const ChattingRoomScreen = () => {
             )}
 
             {/* 프로필 모달 */}
-            <ProfileModal visible={profileVisible} userData={selectedUser} onClose={() => setProfileVisible(false)} />
+            <ProfileModal
+              visible={profileVisible}
+              userData={selectedUser}
+              onClose={() => setProfileVisible(false)}
+              routeType="replace"
+            />
 
             {/* 번역 버튼 추후 변경 혹은 삭제 예정 */}
             {/* <TranslateButton /> */}

--- a/app/chat/[roomId]/members/index.tsx
+++ b/app/chat/[roomId]/members/index.tsx
@@ -57,7 +57,13 @@ const ChatInsideMember = () => {
         />
 
         {/* Profile Modal */}
-        <ProfileModal visible={profileVisible} userData={selectedUser} onClose={() => setProfileVisible(false)} />
+        <ProfileModal
+          visible={profileVisible}
+          userData={selectedUser}
+          onClose={() => setProfileVisible(false)}
+          routeType="replace"
+          dissMissCount={1}
+        />
 
         {/* Leave Chat Button */}
         <LeaveChatButton onPress={handleLeaveChat} />

--- a/src/features/chat/room/hooks/useChatMessages.ts
+++ b/src/features/chat/room/hooks/useChatMessages.ts
@@ -13,7 +13,7 @@ interface ChatMessagesHook {
 
 export const useChatMessages = (roomId: string): ChatMessagesHook => {
   const myUserIdRef = useRef<string>('');
-
+  const currentRoomIdRef = useRef<string>(roomId);
   const stompConnection = useStompStore((state) => state);
 
   // Chat Store에서 필요한 상태와 액션 가져오기
@@ -31,13 +31,13 @@ export const useChatMessages = (roomId: string): ChatMessagesHook => {
   useEffect(() => {
     const init = async () => {
       initialize();
-
       // 번역 상태 설정
       await updateTranslateStateAPI(roomId, true);
+      // 현재 Room ID 업데이트
+      currentRoomIdRef.current = roomId;
     };
 
     init();
-
     return () => {
       reset();
     };
@@ -45,7 +45,7 @@ export const useChatMessages = (roomId: string): ChatMessagesHook => {
 
   /** 메시지 로드(+무한 스크롤) */
   const loadMessages = useCallback(async () => {
-    if (!state.hasMore || state.isFetchingMore) return;
+    if (!state.hasMore || state.isFetchingMore || currentRoomIdRef.current !== roomId) return;
 
     setFetchingMore(true);
 

--- a/src/features/chat/room/hooks/useCreateOneToOneRoom.ts
+++ b/src/features/chat/room/hooks/useCreateOneToOneRoom.ts
@@ -8,6 +8,7 @@ type CreateRoomVars = {
   otherUserId: number;
   userName: string;
   routeType?: 'push' | 'replace';
+  dissMissCount?: number;
   closeProfile?: () => void;
 };
 
@@ -35,6 +36,10 @@ export function useCreateOneToOneRoom() {
         variables.closeProfile();
       }
 
+      if (variables.dissMissCount !== undefined && router.canDismiss()) {
+        router.dismiss(variables.dissMissCount);
+      }
+
       // 채팅방으로 이동
       const navigation = variables.routeType === 'replace' ? router.replace : router.push;
       navigation({
@@ -43,8 +48,6 @@ export function useCreateOneToOneRoom() {
           roomName: variables.userName,
         },
       });
-
-      console.log('채팅방 생성 및 이동 완료 - roomId:', roomId);
     },
   });
 }

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -1,5 +1,6 @@
 import CustomBottomSheet from '@/src/shared/components/CustomBottomSheet';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { usePathname } from 'expo-router';
 import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components/native';
 import { useLinkedSpaceRecommend } from '../hooks/useLinkedSpaceRecommend';
@@ -14,6 +15,9 @@ interface Props {
 export const LinkedSpaceRecommendModal = ({ visible, onJoin, onDontShowToday, onClose }: Props) => {
   const bottomSheetRef = useRef<BottomSheetModal | null>(null);
   const { data } = useLinkedSpaceRecommend(visible);
+  const pathname = usePathname();
+
+  console.info('pathname in LinkedSpaceRecommendModal:', pathname);
 
   // visible이 변경될 때 모달을 열거나 닫음
   useEffect(() => {
@@ -25,7 +29,7 @@ export const LinkedSpaceRecommendModal = ({ visible, onJoin, onDontShowToday, on
   }, [visible, data]);
 
   // data가 없으면 모달을 렌더링하지 않음
-  if (!visible || !data) {
+  if (!visible || !data || !pathname.endsWith('/')) {
     return null;
   }
 

--- a/src/features/find/components/LinkedSpaceRecommendModal.tsx
+++ b/src/features/find/components/LinkedSpaceRecommendModal.tsx
@@ -17,8 +17,6 @@ export const LinkedSpaceRecommendModal = ({ visible, onJoin, onDontShowToday, on
   const { data } = useLinkedSpaceRecommend(visible);
   const pathname = usePathname();
 
-  console.info('pathname in LinkedSpaceRecommendModal:', pathname);
-
   // visible이 변경될 때 모달을 열거나 닫음
   useEffect(() => {
     if (visible && data) {

--- a/src/features/notification/hooks/useBackgroundNotiification.ts
+++ b/src/features/notification/hooks/useBackgroundNotiification.ts
@@ -1,32 +1,97 @@
-import { useEffect } from 'react';
+import { getNotificationDeeplink } from '@/src/features/notification/lib/getNotificationDeeplink';
+import { CHAT_ROUTE } from '@/src/shared/constants/route';
 import messaging from '@react-native-firebase/messaging';
 import * as Linking from 'expo-linking';
-import { getNotificationDeeplink } from '@/src/features/notification/lib/getNotificationDeeplink';
+import { usePathname, useRouter } from 'expo-router';
+import * as SecureStore from 'expo-secure-store';
+import { useEffect } from 'react';
+
+const PENDING_KEY = 'PENDING_NOTIFICATION_URL';
 
 /* ------------ Background 또는 Quit 메시지 수신 및 클릭 핸들링 ------------ */
 export const useBackgroundNotification = (isLoggedIn: boolean, checkingToken: boolean) => {
+  const router = useRouter();
+  const pathname = usePathname();
+
   useEffect(() => {
-    if (!isLoggedIn || checkingToken) return;
+    // 항상 초기/열림 알림 확인 및 리스너 등록
+    let unsub: (() => void) | undefined;
+
+    const navigateOrStore = async (data: { [key: string]: string | number | object } | undefined) => {
+      if (!data) return;
+      const deeplink = getNotificationDeeplink(data) ?? '/';
+      // 인증 전이면 임시 저장
+      if (!isLoggedIn || checkingToken) {
+        await SecureStore.setItemAsync(PENDING_KEY, JSON.stringify({ deeplink, data }));
+        return;
+      }
+
+      // 현재 경로에 따라 replace / dismiss+replace / push 결정 (chat 전용 사례)
+      if (String(data.type) === 'chat') {
+        const roomId = String((data as any).roomId);
+        const roomName = String((data as any).roomName ?? '');
+        const isChatRoomPath = /^\/chat\/[^\/]+$/.test(pathname ?? '');
+        const isChatMembersPath = /^\/chat\/[^\/]+\/members$/.test(pathname ?? '');
+
+        if (isChatRoomPath) {
+          router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
+          return;
+        }
+        if (isChatMembersPath) {
+          router.dismiss(1);
+          setTimeout(() => router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } }), 300);
+          return;
+        }
+        router.push({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
+        return;
+      }
+
+      // chat 이외는 deeplink 열기(기존 행동 유지)
+      Linking.openURL(deeplink).catch(() => {});
+    };
 
     messaging()
       .getInitialNotification()
       .then((message) => {
         if (message) {
-          const url = getNotificationDeeplink(message.data!) ?? '/';
-          Linking.openURL(url);
+          console.info('[INFO] 앱 종료 상태에서 알림 클릭으로 앱 실행됨:', message);
+          navigateOrStore(message.data);
+        } else {
+          // no initial notification
         }
       })
       .catch((error) => {
         console.error('[ERROR] 앱 종료 시 알림 클릭 후 이동 실패:', error);
       });
 
-    const unsubscribe = messaging().onNotificationOpenedApp((message) => {
+    unsub = messaging().onNotificationOpenedApp((message) => {
       if (message) {
-        const url = getNotificationDeeplink(message.data!) ?? '/';
-        Linking.openURL(url);
+        navigateOrStore(message.data);
       }
     });
 
-    return unsubscribe;
+    return () => {
+      if (unsub) unsub();
+    };
+  }, [isLoggedIn, checkingToken, router, pathname]);
+
+  // 인증 완료 시(또는 checkingToken -> false, isLoggedIn true) 보관된 알림 처리
+  useEffect(() => {
+    const processPending = async () => {
+      if (!isLoggedIn || checkingToken) return;
+      const raw = await SecureStore.getItemAsync(PENDING_KEY);
+      if (!raw) return;
+      try {
+        const { data } = JSON.parse(raw);
+        await SecureStore.deleteItemAsync(PENDING_KEY);
+        // 저장된 data로 네비게이트
+        const deeplink = getNotificationDeeplink(data) ?? '/';
+        // chat 전용 로직은 위와 동일하게 처리하면 됨; 간단하게 Linking으로 열어도 무방
+        Linking.openURL(deeplink).catch(() => {});
+      } catch (e) {
+        await SecureStore.deleteItemAsync(PENDING_KEY);
+      }
+    };
+    processPending();
   }, [isLoggedIn, checkingToken]);
 };

--- a/src/features/notification/hooks/useBackgroundNotiification.ts
+++ b/src/features/notification/hooks/useBackgroundNotiification.ts
@@ -37,7 +37,6 @@ export const useBackgroundNotification = (isLoggedIn: boolean, checkingToken: bo
       .getInitialNotification()
       .then((message) => {
         if (message) {
-          console.info('[INFO] 앱 종료 상태에서 알림 클릭으로 앱 실행됨:', message);
           navigateOrStore(message.data);
         } else {
           // no initial notification

--- a/src/features/notification/hooks/useBackgroundNotiification.ts
+++ b/src/features/notification/hooks/useBackgroundNotiification.ts
@@ -1,5 +1,5 @@
 import { getNotificationDeeplink } from '@/src/features/notification/lib/getNotificationDeeplink';
-import { CHAT_ROUTE } from '@/src/shared/constants/route';
+import { handleChatNotificationNavigation } from '@/src/features/notification/lib/notificationNavigator';
 import messaging from '@react-native-firebase/messaging';
 import * as Linking from 'expo-linking';
 import { usePathname, useRouter } from 'expo-router';
@@ -26,25 +26,9 @@ export const useBackgroundNotification = (isLoggedIn: boolean, checkingToken: bo
         return;
       }
 
-      // 현재 경로에 따라 replace / dismiss+replace / push 결정 (chat 전용 사례)
-      if (String(data.type) === 'chat') {
-        const roomId = String((data as any).roomId);
-        const roomName = String((data as any).roomName ?? '');
-        const isChatRoomPath = /^\/chat\/[^\/]+$/.test(pathname ?? '');
-        const isChatMembersPath = /^\/chat\/[^\/]+\/members$/.test(pathname ?? '');
-
-        if (isChatRoomPath) {
-          router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
-          return;
-        }
-        if (isChatMembersPath) {
-          router.dismiss(1);
-          setTimeout(() => router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } }), 300);
-          return;
-        }
-        router.push({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
-        return;
-      }
+      // chat 전용 네비게이션은 공통 유틸로 처리하고, 처리되지 않으면 deeplink 열기
+      const handled = handleChatNotificationNavigation({ router, pathname, data, pushDelay: 0, dismissDelay: 300 });
+      if (handled) return;
 
       // chat 이외는 deeplink 열기(기존 행동 유지)
       Linking.openURL(deeplink).catch(() => {});

--- a/src/features/notification/hooks/useBackgroundNotiification.ts
+++ b/src/features/notification/hooks/useBackgroundNotiification.ts
@@ -2,7 +2,7 @@ import { getNotificationDeeplink } from '@/src/features/notification/lib/getNoti
 import { handleChatNotificationNavigation } from '@/src/features/notification/lib/notificationNavigator';
 import messaging from '@react-native-firebase/messaging';
 import * as Linking from 'expo-linking';
-import { usePathname, useRouter } from 'expo-router';
+import { router, usePathname } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
 import { useEffect } from 'react';
 
@@ -10,7 +10,6 @@ const PENDING_KEY = 'PENDING_NOTIFICATION_URL';
 
 /* ------------ Background 또는 Quit 메시지 수신 및 클릭 핸들링 ------------ */
 export const useBackgroundNotification = (isLoggedIn: boolean, checkingToken: boolean) => {
-  const router = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
@@ -27,7 +26,7 @@ export const useBackgroundNotification = (isLoggedIn: boolean, checkingToken: bo
       }
 
       // chat 전용 네비게이션은 공통 유틸로 처리하고, 처리되지 않으면 deeplink 열기
-      const handled = handleChatNotificationNavigation({ router, pathname, data, pushDelay: 0, dismissDelay: 300 });
+      const handled = handleChatNotificationNavigation({ pathname, data, pushDelay: 0, dismissDelay: 300 });
       if (handled) return;
 
       // chat 이외는 deeplink 열기(기존 행동 유지)

--- a/src/features/notification/lib/getNotificationDeeplink.ts
+++ b/src/features/notification/lib/getNotificationDeeplink.ts
@@ -14,7 +14,7 @@ export function getNotificationDeeplink(data: { [key: string]: string | number |
         return `korifront://(tabs)/community/${data.postId}`;
 
       case 'chat':
-        return `korifront://chat/${data.roomId}?myId=${data.myId}`;
+        return `korifront://chat/${data.roomId}?roomName=${data.roomName}`;
 
       case 'follow':
         return `korifront://(tabs)/mypage/follows?followerId=${data.followerId}`;

--- a/src/features/notification/lib/messageHandler.ts
+++ b/src/features/notification/lib/messageHandler.ts
@@ -1,4 +1,4 @@
-import { CHAT_ROUTE } from '@/src/shared/constants/route';
+import { handleChatNotificationNavigation } from '@/src/features/notification/lib/notificationNavigator';
 import notifee, { AndroidImportance, EventType } from '@notifee/react-native';
 import { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import { Href, router } from 'expo-router';
@@ -92,38 +92,8 @@ export function notificationRouterReplace(data: { [key: string]: string | number
       break;
 
     case 'chat':
-      // 경로가 `/chat/:roomId` 또는 `/chat/:roomId/members` 인지 검사
-      const isChatRoomPath = /^\/chat\/[^\/]+$/.test(pathname);
-      const isChatMembersPath = /^\/chat\/[^\/]+\/members$/.test(pathname);
-
-      if (isChatRoomPath) {
-        // 같은 채팅방 화면에서 들어온 알림은 replace
-        router.replace({
-          pathname: CHAT_ROUTE(String(data.roomId)),
-          params: { roomName: String(data.roomName) },
-        });
-        return;
-      }
-
-      if (isChatMembersPath) {
-        // 멤버 목록 화면이면 뒤로 한 단계(dismiss)한 뒤 replace
-        router.dismiss(1);
-        setTimeout(() => {
-          router.replace({
-            pathname: CHAT_ROUTE(String(data.roomId)),
-            params: { roomName: String(data.roomName) },
-          });
-        }, 500);
-        return;
-      }
-
-      // 그 외 화면에서는 push
-      setTimeout(() => {
-        router.navigate({
-          pathname: CHAT_ROUTE(String(data.roomId)),
-          params: { roomName: String(data.roomName) },
-        });
-      }, 500);
+      // 채팅 관련 네비게이션을 공통 유틸로 위임
+      if (handleChatNotificationNavigation({ router, pathname, data })) return;
       break;
 
     case 'follow':

--- a/src/features/notification/lib/messageHandler.ts
+++ b/src/features/notification/lib/messageHandler.ts
@@ -93,10 +93,11 @@ export function notificationRouterReplace(data: { [key: string]: string | number
 
     case 'chat':
       if (!pathname.includes('chat')) router.replace('/chat');
+      console.info('data.roomId', data);
       setTimeout(() => {
         router.push({
           pathname: CHAT_ROUTE(String(data.roomId)) as RelativePathString,
-          params: { myId: String(data.myId) },
+          params: { roomName: String(data.roomName) },
         });
       }, 500);
       break;

--- a/src/features/notification/lib/messageHandler.ts
+++ b/src/features/notification/lib/messageHandler.ts
@@ -1,7 +1,7 @@
 import { CHAT_ROUTE } from '@/src/shared/constants/route';
 import notifee, { AndroidImportance, EventType } from '@notifee/react-native';
 import { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
-import { Href, RelativePathString, router } from 'expo-router';
+import { Href, router } from 'expo-router';
 import { Platform } from 'react-native';
 
 /* --------------- push를 notifee로 표시 --------------- */
@@ -92,11 +92,36 @@ export function notificationRouterReplace(data: { [key: string]: string | number
       break;
 
     case 'chat':
-      if (!pathname.includes('chat')) router.replace('/chat');
-      console.info('data.roomId', data);
+      console.info('pathname', pathname);
+      // 경로가 `/chat/:roomId` 또는 `/chat/:roomId/members` 인지 검사
+      const isChatRoomPath = /^\/chat\/[^\/]+$/.test(pathname);
+      const isChatMembersPath = /^\/chat\/[^\/]+\/members$/.test(pathname);
+
+      if (isChatRoomPath) {
+        // 같은 채팅방 화면에서 들어온 알림은 replace
+        router.replace({
+          pathname: CHAT_ROUTE(String(data.roomId)),
+          params: { roomName: String(data.roomName) },
+        });
+        return;
+      }
+
+      if (isChatMembersPath) {
+        // 멤버 목록 화면이면 뒤로 한 단계(dismiss)한 뒤 replace
+        router.back();
+        setTimeout(() => {
+          router.replace({
+            pathname: CHAT_ROUTE(String(data.roomId)),
+            params: { roomName: String(data.roomName) },
+          });
+        }, 500);
+        return;
+      }
+
+      // 그 외 화면에서는 push
       setTimeout(() => {
-        router.push({
-          pathname: CHAT_ROUTE(String(data.roomId)) as RelativePathString,
+        router.navigate({
+          pathname: CHAT_ROUTE(String(data.roomId)),
           params: { roomName: String(data.roomName) },
         });
       }, 500);

--- a/src/features/notification/lib/messageHandler.ts
+++ b/src/features/notification/lib/messageHandler.ts
@@ -93,7 +93,7 @@ export function notificationRouterReplace(data: { [key: string]: string | number
 
     case 'chat':
       // 채팅 관련 네비게이션을 공통 유틸로 위임
-      if (handleChatNotificationNavigation({ router, pathname, data })) return;
+      if (handleChatNotificationNavigation({ pathname, data })) return;
       break;
 
     case 'follow':

--- a/src/features/notification/lib/messageHandler.ts
+++ b/src/features/notification/lib/messageHandler.ts
@@ -92,7 +92,6 @@ export function notificationRouterReplace(data: { [key: string]: string | number
       break;
 
     case 'chat':
-      console.info('pathname', pathname);
       // 경로가 `/chat/:roomId` 또는 `/chat/:roomId/members` 인지 검사
       const isChatRoomPath = /^\/chat\/[^\/]+$/.test(pathname);
       const isChatMembersPath = /^\/chat\/[^\/]+\/members$/.test(pathname);
@@ -108,7 +107,7 @@ export function notificationRouterReplace(data: { [key: string]: string | number
 
       if (isChatMembersPath) {
         // 멤버 목록 화면이면 뒤로 한 단계(dismiss)한 뒤 replace
-        router.back();
+        router.dismiss(1);
         setTimeout(() => {
           router.replace({
             pathname: CHAT_ROUTE(String(data.roomId)),

--- a/src/features/notification/lib/notificationNavigator.ts
+++ b/src/features/notification/lib/notificationNavigator.ts
@@ -1,4 +1,5 @@
 import { CHAT_ROUTE } from '@/src/shared/constants/route';
+import { router } from 'expo-router';
 
 type RouterLike = any;
 
@@ -7,13 +8,12 @@ type RouterLike = any;
  * Returns true if the data was handled as a chat notification.
  */
 export function handleChatNotificationNavigation(opts: {
-  router: RouterLike;
   pathname: string | null | undefined;
   data: { [key: string]: string | number | object } | undefined;
   pushDelay?: number;
   dismissDelay?: number;
 }): boolean {
-  const { router, pathname, data, pushDelay = 500, dismissDelay = 300 } = opts;
+  const { pathname, data, pushDelay = 500, dismissDelay = 300 } = opts;
   if (!data) return false;
   if (String(data.type) !== 'chat') return false;
 
@@ -31,8 +31,7 @@ export function handleChatNotificationNavigation(opts: {
 
   if (isChatMembersPath) {
     // 멤버 목록 화면이면 dismiss 후 replace
-    if (typeof router.dismiss === 'function') router.dismiss(1);
-    else if (typeof router.back === 'function') router.back();
+    if (router.canDismiss()) router.dismiss(1);
     setTimeout(() => {
       router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
     }, dismissDelay);
@@ -41,11 +40,7 @@ export function handleChatNotificationNavigation(opts: {
 
   // 그 외는 push (navigate 또는 push)
   setTimeout(() => {
-    if (typeof router.navigate === 'function') {
-      router.navigate({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
-    } else {
-      router.push({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
-    }
+    router.navigate({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
   }, pushDelay);
 
   return true;

--- a/src/features/notification/lib/notificationNavigator.ts
+++ b/src/features/notification/lib/notificationNavigator.ts
@@ -1,0 +1,52 @@
+import { CHAT_ROUTE } from '@/src/shared/constants/route';
+
+type RouterLike = any;
+
+/**
+ * Handle chat-specific navigation for notifications.
+ * Returns true if the data was handled as a chat notification.
+ */
+export function handleChatNotificationNavigation(opts: {
+  router: RouterLike;
+  pathname: string | null | undefined;
+  data: { [key: string]: string | number | object } | undefined;
+  pushDelay?: number;
+  dismissDelay?: number;
+}): boolean {
+  const { router, pathname, data, pushDelay = 500, dismissDelay = 300 } = opts;
+  if (!data) return false;
+  if (String(data.type) !== 'chat') return false;
+
+  const roomId = String((data as any).roomId);
+  const roomName = String((data as any).roomName ?? '');
+
+  const isChatRoomPath = /^\/chat\/[^\/]+$/.test(pathname ?? '');
+  const isChatMembersPath = /^\/chat\/[^\/]+\/members$/.test(pathname ?? '');
+
+  if (isChatRoomPath) {
+    // 같은 채팅방 화면이면 replace
+    router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
+    return true;
+  }
+
+  if (isChatMembersPath) {
+    // 멤버 목록 화면이면 dismiss 후 replace
+    if (typeof router.dismiss === 'function') router.dismiss(1);
+    else if (typeof router.back === 'function') router.back();
+    setTimeout(() => {
+      router.replace({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
+    }, dismissDelay);
+    return true;
+  }
+
+  // 그 외는 push (navigate 또는 push)
+  setTimeout(() => {
+    if (typeof router.navigate === 'function') {
+      router.navigate({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
+    } else {
+      router.push({ pathname: CHAT_ROUTE(roomId), params: { roomName } });
+    }
+  }, pushDelay);
+
+  return true;
+}

--- a/src/features/notification/lib/notificationNavigator.ts
+++ b/src/features/notification/lib/notificationNavigator.ts
@@ -1,8 +1,6 @@
 import { CHAT_ROUTE } from '@/src/shared/constants/route';
 import { router } from 'expo-router';
 
-type RouterLike = any;
-
 /**
  * Handle chat-specific navigation for notifications.
  * Returns true if the data was handled as a chat notification.

--- a/src/shared/components/ProfileModal.tsx
+++ b/src/shared/components/ProfileModal.tsx
@@ -34,7 +34,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ visible, userData, onClose,
     createChatRoom.mutate({
       otherUserId: userData.userId,
       userName: `${userData.firstname} ${userData.lastname}`,
-      routeType: 'replace',
+      routeType: 'push',
       closeProfile: onClose,
     });
   };

--- a/src/shared/components/ProfileModal.tsx
+++ b/src/shared/components/ProfileModal.tsx
@@ -12,9 +12,19 @@ type ProfileModalProps = {
   onClose: () => void;
   isLoadingFollow?: boolean;
   isLoadingChat?: boolean;
+  routeType?: 'push' | 'replace';
+  dissMissCount?: number;
 };
 
-const ProfileModal: React.FC<ProfileModalProps> = ({ visible, userData, onClose, isLoadingFollow, isLoadingChat }) => {
+const ProfileModal: React.FC<ProfileModalProps> = ({
+  visible,
+  userData,
+  onClose,
+  isLoadingFollow,
+  isLoadingChat,
+  routeType = 'push',
+  dissMissCount,
+}) => {
   const followUserMutation = useFollowUserMutation();
   const unfollowUserMutation = useUnfollowUserMutation();
   const createChatRoom = useCreateOneToOneRoom();
@@ -34,7 +44,8 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ visible, userData, onClose,
     createChatRoom.mutate({
       otherUserId: userData.userId,
       userName: `${userData.firstname} ${userData.lastname}`,
-      routeType: 'push',
+      routeType: routeType,
+      dissMissCount: dissMissCount,
       closeProfile: onClose,
     });
   };


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요
- 이슈: 채팅방에서 다른 채팅방으로 직접 이동할 때(예: 알림, 프로필 카드), 이전 채팅방의 메시지가 잔류하는 현상 해결
- 핵심 변경사항
    - 채팅방 이동 시 Navigation Stack 관리 전략 수정 (push -> replace) 
    - 불필요한 API 중복 호출 방지 및 상태 초기화 로직 보강 
    - 알림/프로필을 통한 진입 경로별 라우팅 대응

## 🔍 작업 상세 내용

#### 메시지 상태 구조 유지
- 현재 우리 서비스는 여러 채팅방을 동시에 띄우지 않는 단일 활성 구조입니다. (여러 채팅방을 띄우는 서비스 ex. pc 카카오톡)
따라서 문제 상황을 해결하기 위해 roomId를 Key로 하는 Map 구조를 도입하는 대신
메모리 관리 효율과 구현 복잡도를 고려하여 단일 상태를 유지하되 진입/이탈 시점의 데이터 무결성을 확보하는 방향을 택했습니다.

#### 문제 원인 분석
1. 라우트 스택 중첩: 채팅방 위로 새로운 채팅방이 push될 때 이전 컴포넌트가 언마운트되지 않아 소켓 구독이 유지되고 데이터가 섞이는 현상이 발생했습니다.
2. API 레이스 컨디션: API호출 Log 확인 결과 채팅방 변경 시점에 이전 roomId에 대한 메시지 로드 API가 뒤늦게 호출되어 현재 방의 데이터에 영향을 주는 것을 확인했습니다.

#### 해결 방법
- Navigation 전략 수정: 동일한 채팅방 컴포넌트가 쌓이지 않도록, 채팅방 간 이동 시에는 `route.replace`와 `route.dissmiss`를 사용하여 이전 스택을 관리하였습니다.
- 진입 경로별 최적화:
    - 프로필 카드/알림을 통한 이동: `replace` 또는 `dismiss` 후 이동하여 비정상적인 '뒤로가기' 흐름(채팅방 > 채팅방) 방지.
    - 일반 진입: UX 일관성을 위해 `push` 유지 및 `history.back` 대응.
- useRef: `useChatMessages.ts` 훅 내에서 현재 사용자가 보고 있는 화면의 roomId를 관리하기 위한 `currentRoomIdRef`를 두어 이전 채팅방에 대한 메시지 호출 API가 실행되지 않도록 수정.

#### UX 고려사항
- 뒤로가기 시 항상 채팅 목록으로 가는 방식보다, **사용자가 직전에 머물렀던 페이지**로 돌아가는 것이 iOS/안드로이드 시스템 표준 제스처와 부합한다고 판단하여 이를 유지했습니다.

## ✅ 체크리스트

-   [x] 빌드가 실패 없이 완료되었나요?
-   [x] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [x] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [x] 불필요한 console.log, 주석을 제거했나요?
-   [x] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #229 
