### PR TITLE
[Feat/#248] k-culture 메인페이지 1차 구현 - 뉴스 상세페이지 구현 (pr 2)

### DIFF
--- a/app/(tabs)/community/index.tsx
+++ b/app/(tabs)/community/index.tsx
@@ -28,7 +28,7 @@ export default function CommunityScreen() {
 
   return (
     <Safe>
-      <Header>
+      <HeaderRow>
         <Left>
           <TextButton onPress={() => scrollToTop(true)} activeOpacity={0.6}>
             <Title>Community</Title>
@@ -66,7 +66,7 @@ export default function CommunityScreen() {
             <Icon type="person" size={24} color={theme.colors.gray.lightGray_1} />
           </IconBtn>
         </Right>
-      </Header>
+      </HeaderRow>
 
       <ChipsWrap>
         <CategoryChips value={category} onPress={handleCategoryChange} />
@@ -88,8 +88,8 @@ const Safe = styled.SafeAreaView`
   flex: 1;
   background: #1d1e1f;
 `;
-const Header = styled.View`
-  padding: 0 12px;
+const HeaderRow = styled.View`
+  padding: 0 20px;
   margin-top: 12px;
   flex-direction: row;
   align-items: center;
@@ -98,7 +98,6 @@ const Header = styled.View`
 const Left = styled.View`
   flex-direction: row;
   align-items: center;
-  margin-left: 10px;
 `;
 const TextButton = styled.TouchableOpacity``;
 const Title = styled.Text`

--- a/app/k-culture/detail/[newsId].tsx
+++ b/app/k-culture/detail/[newsId].tsx
@@ -1,0 +1,88 @@
+import Icon from '@/components/common/Icon';
+import { useGetNewsDetail } from '@/src/features/k-culture/hooks/useGetNewsDetail';
+import { makeCompleteHtml } from '@/src/features/k-culture/utils/makeCompleteHtml';
+import { confirmOpenURL } from '@/src/shared/utils/confirmOpenURL';
+import { textStyle, theme } from '@/src/styles/theme';
+import { SCREEN_WIDTH } from '@gorhom/bottom-sheet';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useMemo } from 'react';
+import { ActivityIndicator, Text, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+import styled from 'styled-components/native';
+
+const NewsId = () => {
+  const { newsId } = useLocalSearchParams<{ newsId: string }>();
+  const { data, isLoading, isError } = useGetNewsDetail(Number(newsId));
+
+  const finalHtmlContent = useMemo(() => {
+    if (!data) return '';
+    return makeCompleteHtml(data.title, data.htmlContent);
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Error loading news detail.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Safe>
+      <Header>
+        <Back onPress={() => router.back()}>
+          <Icon type="previous" size={24} color={theme.colors.gray.lightGray_1} />
+        </Back>
+        <HeaderTitle>{data.title}</HeaderTitle>
+        <RightPlaceholder />
+      </Header>
+
+      <WebView
+        contentWidth={SCREEN_WIDTH}
+        source={{ html: finalHtmlContent }}
+        onShouldStartLoadWithRequest={(event) => {
+          if (event.url.startsWith('http') || event.url.startsWith('https')) {
+            confirmOpenURL(event.url);
+            return false;
+          }
+          return true;
+        }}
+      />
+    </Safe>
+  );
+};
+
+export default NewsId;
+
+const Safe = styled.SafeAreaView`
+  flex: 1;
+  background: #1d1e1f;
+  gap: 10px;
+`;
+const Header = styled.View`
+  padding: 11px 20px 16px 20px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+const Back = styled.Pressable`
+  width: 40px;
+  align-items: flex-start;
+`;
+const HeaderTitle = styled.Text`
+  ${({ theme }) => textStyle(theme.fonts.body.B2_M)};
+  color: ${({ theme }) => theme.colors.primary.white};
+  text-align: center;
+  flex: 1;
+`;
+const RightPlaceholder = styled.View`
+  width: 40px;
+`;

--- a/src/features/k-culture/hooks/useGetNewsDetail.ts
+++ b/src/features/k-culture/hooks/useGetNewsDetail.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getNewsDetail } from '../apis/news';
+import { KCultureNewsItem } from '../types';
+
+export const useGetNewsDetail = (contentId: number) => {
+  return useQuery<KCultureNewsItem>({
+    queryKey: ['news', 'detail', contentId],
+    queryFn: () => getNewsDetail(contentId),
+    enabled: !!contentId,
+  });
+};

--- a/src/features/k-culture/utils/makeCompleteHtml.ts
+++ b/src/features/k-culture/utils/makeCompleteHtml.ts
@@ -1,0 +1,45 @@
+import { theme } from '@/src/styles/theme';
+
+// K-컬처 뉴스 상세의 HTML 콘텐츠가 불완전한 경우, 완전한 HTML 문서로 감싸주는 유틸 함수
+export const makeCompleteHtml = (title: string, htmlContent: string) => {
+  if (!htmlContent) return '';
+
+  const isCompleteHtml = /<html/i.test(htmlContent) || /<!DOCTYPE/i.test(htmlContent);
+
+  if (isCompleteHtml) {
+    return htmlContent;
+  }
+
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>${title}</title>
+      <style>
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+          margin: 16px;
+          color: ${theme.colors.primary.white};
+          background-color: ${theme.colors.primary.black};
+        }
+        a {
+          color: ${theme.colors.primary.mint};
+          text-decoration: none;
+        }
+        a:hover {
+          text-decoration: underline;
+        }
+        img, video, iframe {
+          max-width: 100%; !important;
+          height: auto; !important;
+        }
+      </style>
+    </head>
+    <body>
+      ${htmlContent}
+    </body>
+    </html>
+  `;
+};

--- a/src/features/k-culture/utils/timeStampToAgo.ts
+++ b/src/features/k-culture/utils/timeStampToAgo.ts
@@ -1,0 +1,20 @@
+export const timeStampToAgo = (timestamp: number): string => {
+  if (!timestamp) return 'Unknown time ago';
+
+  const now = Date.now();
+
+  const secondsAgo = Math.floor((now - timestamp) / 1000);
+
+  if (secondsAgo < 60) {
+    return 'Just now';
+  } else if (secondsAgo < 3600) {
+    const minutes = Math.floor(secondsAgo / 60);
+    return `${minutes}m ago`;
+  } else if (secondsAgo < 86400) {
+    const hours = Math.floor(secondsAgo / 3600);
+    return `${hours}h ago`;
+  } else {
+    const days = Math.floor(secondsAgo / 86400);
+    return `${days}d ago`;
+  }
+};


### PR DESCRIPTION
<!-- @format -->

### ⚠️ pr 의존성 문제로 pr1, 2는 제가 머지하겠습니다! 승인만 부탁드립니다. 그리고 테스트 시에는 해당 pr 2 브랜치에서 진행하시면 됩니다!

## 📌 작업 개요

-   뉴스 상세페이지 구현을 완료했습니다. 

## 🔍 작업 상세 내용
### 1️⃣ react-native-webview로 서버 HTML 렌더링
- 외부 url 열 수 있도록 confirmOpenUrL() 함수 적용
```typescript
onShouldStartLoadWithRequest={(event) => {
          if (event.url.startsWith('http') || event.url.startsWith('https')) {
            confirmOpenURL(event.url);
            return false;
          }
          return true;
        }}
```
- html 구조에서 body만 넘어오는 데이터 처리를 위해 `makeCompleteHtml` 유틸 함수 생성 및 적용
```typescript
  const finalHtmlContent = useMemo(() => {
    if (!data) return '';
    return makeCompleteHtml(data.title, data.htmlContent);
  }, [data]);
```

## 🏞️ 스크린샷
<img width="250" alt="스크린샷 2026-01-02 오전 6 04 08" src="https://github.com/user-attachments/assets/813fc85f-ff0f-48db-aa84-33dfedade08b" />

⚠️ 뉴스 헤더 타이틀은 어떤 식으로 보여줄지 디자이너님과 논의 중에 있습니다.  

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #이슈번호
