### PR TITLE
[Feat/#240] Friend Status 개선

### DIFF
--- a/api/mypage/mypage.ts
+++ b/api/mypage/mypage.ts
@@ -1,6 +1,13 @@
 import api from '@/api/axiosInstance';
 
-export type FollowStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
+export type FollowStatus =
+  | 'PENDING'
+  | 'ACCEPTED'
+  | 'REJECTED' //이전 상태
+  | 'FRIEND'
+  | 'FOLLOWING'
+  | 'FOLLOWED'
+  | 'NONE';
 
 export type Profile = {
   firstname?: string;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { LinkedSpaceRecommendModal } from '@/src/features/find/components/Linked
 import { useLinkedSpaceRecommendModal } from '@/src/features/find/hooks/useLinkedSpaceRecommendModal';
 import { useRecommendedFriends } from '@/src/features/find/hooks/useRecommendedFriends';
 import UserProfileCard from '@/src/shared/components/UserProfileCard';
-import { useFollowUserMutation } from '@/src/shared/hooks/useUserProfileQuery';
+import { useCancelFollowUserMutation, useFollowUserMutation } from '@/src/shared/hooks/useUserProfileQuery';
 import { Text } from '@react-navigation/elements';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect, useRef, useState } from 'react';
@@ -23,6 +23,7 @@ export default function index() {
 
   const createChatRoom = useCreateOneToOneRoom();
   const followMutation = useFollowUserMutation();
+  const cancelFollowMutation = useCancelFollowUserMutation();
 
   const {
     visible: recommendVisible,
@@ -46,11 +47,11 @@ export default function index() {
   // Define card actions based on follow status
   const getCardActions = (item: NonNullable<typeof friends>[0]) => {
     return {
-      ...(item.followStatus === 'PENDING'
+      ...(item.followStatus === 'PENDING' || item.followStatus === 'FOLLOWING'
         ? {
             secondary: {
               label: 'Following',
-              onPress: () => {},
+              onPress: () => cancelFollowMutation.mutate(item.userId),
             },
           }
         : {

--- a/components/CommentItem.tsx
+++ b/components/CommentItem.tsx
@@ -173,7 +173,7 @@ export default function CommentItem({ data, onPressLike, isFirst, onPressMore, o
     setIsFollowLoading(true);
 
     try {
-      await api.post(`/api/v1/home/follow/${targetUserId}`);
+      await api.post(`/api/v1/mypage/follow/${targetUserId}`);
       setSelectedUser((prevUser) => ({
         ...(prevUser as any),
         followStatus: 'PENDING',

--- a/src/features/find/api/follow.ts
+++ b/src/features/find/api/follow.ts
@@ -22,7 +22,7 @@ function mapDummyToReal(userId: number) {
  */
 export async function postFollow(userId: number): Promise<FollowResponse> {
   const targetId = mapDummyToReal(userId);
-  const { data } = await api.post<FollowResponse>(`/api/v1/home/follow/${targetId}`, {});
+  const { data } = await api.post<FollowResponse>(`/api/v1/mypage/follow/${targetId}`, {});
   return data;
 }
 

--- a/src/shared/api/userProfile.ts
+++ b/src/shared/api/userProfile.ts
@@ -18,3 +18,9 @@ export const unfollowUser = async (userId: number) => {
   const response = await api.delete(`/api/v1/mypage/follow/${userId}`);
   return response.data;
 };
+
+/** 사용자 팔로우 취소 */
+export const cancelFollowUser = async (userId: number) => {
+  const response = await api.delete(`/api/v1/mypage/users/follow/${userId}`);
+  return response.data;
+};

--- a/src/shared/api/userProfile.ts
+++ b/src/shared/api/userProfile.ts
@@ -9,12 +9,12 @@ export const fetchUserProfile = async (userId: number): Promise<User> => {
 
 /** 사용자 팔로우 */
 export const followUser = async (userId: number) => {
-  const response = await api.post(`/api/v1/home/follow/${userId}`);
+  const response = await api.post(`/api/v1/mypage/follow/${userId}`);
   return response.data;
 };
 
 /** 사용자 언팔로우 */
 export const unfollowUser = async (userId: number) => {
-  const response = await api.delete(`/api/v1/home/follow/${userId}`);
+  const response = await api.delete(`/api/v1/mypage/follow/${userId}`);
   return response.data;
 };

--- a/src/shared/components/ProfileModal.tsx
+++ b/src/shared/components/ProfileModal.tsx
@@ -1,6 +1,10 @@
 import { useCreateOneToOneRoom } from '@/src/features/chat/room/hooks/useCreateOneToOneRoom';
 import UserProfileCard from '@/src/shared/components/UserProfileCard';
-import { useFollowUserMutation, useUnfollowUserMutation } from '@/src/shared/hooks/useUserProfileQuery';
+import {
+  useCancelFollowUserMutation,
+  useFollowUserMutation,
+  useUnfollowUserMutation,
+} from '@/src/shared/hooks/useUserProfileQuery';
 import React from 'react';
 import { ActivityIndicator, Modal, ScrollView } from 'react-native';
 import styled from 'styled-components/native';
@@ -17,6 +21,7 @@ type ProfileModalProps = {
 const ProfileModal: React.FC<ProfileModalProps> = ({ visible, userData, onClose, isLoadingFollow, isLoadingChat }) => {
   const followUserMutation = useFollowUserMutation();
   const unfollowUserMutation = useUnfollowUserMutation();
+  const cancelFollowUserMutation = useCancelFollowUserMutation();
   const createChatRoom = useCreateOneToOneRoom();
 
   const handleFollow = () => {
@@ -27,6 +32,11 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ visible, userData, onClose,
   const handleUnfollow = () => {
     if (!userData) return;
     unfollowUserMutation.mutate(userData.userId);
+  };
+
+  const handleCancelFollow = () => {
+    if (!userData) return;
+    cancelFollowUserMutation.mutate(userData.userId);
   };
 
   const handleChat = () => {
@@ -48,11 +58,12 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ visible, userData, onClose,
               <UserProfileCard
                 user={userData}
                 defaultExpanded={true}
+                // BE 작업 동기화를 위해 이전 상태(ACCEPTED, PENDING) 유지
                 actions={{
-                  ...(userData.followStatus === 'ACCEPTED'
+                  ...(userData.followStatus === 'ACCEPTED' || userData.followStatus === 'FRIEND'
                     ? { decline: { label: 'Unfollow', onPress: handleUnfollow } }
-                    : userData.followStatus === 'PENDING'
-                      ? { secondary: { label: 'Pending', onPress: () => {} } }
+                    : userData.followStatus === 'PENDING' || userData.followStatus === 'FOLLOWING'
+                      ? { secondary: { label: 'Pending', onPress: handleCancelFollow } }
                       : { primary: { label: 'Follow', onPress: handleFollow } }),
                   chat: { label: 'Chat', onPress: handleChat },
                 }}

--- a/src/shared/hooks/useUserProfileQuery.ts
+++ b/src/shared/hooks/useUserProfileQuery.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchUserProfile, followUser, unfollowUser } from '../api/userProfile';
+import { cancelFollowUser, fetchUserProfile, followUser, unfollowUser } from '../api/userProfile';
 
 /** 쿼리 키 */
 export const USER_PROFILE_QK = (userId: number) => ['chat', 'userProfile', userId] as const;
@@ -36,6 +36,21 @@ export const useUnfollowUserMutation = () => {
 
   return useMutation({
     mutationFn: (userId: number) => unfollowUser(userId),
+    onSuccess: (_, userId) => {
+      // 해당 사용자 프로필 캐시 무효화
+      queryClient.invalidateQueries({
+        queryKey: USER_PROFILE_QK(userId),
+      });
+    },
+  });
+};
+
+/** 팔로우 취소 Mutation */
+export const useCancelFollowUserMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => cancelFollowUser(userId),
     onSuccess: (_, userId) => {
       // 해당 사용자 프로필 캐시 무효화
       queryClient.invalidateQueries({


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   @usingjun 님과 논의한 내용을 바탕으로 친구 상태(friend status)를 수정 작업 진행했습니다.

## 🔍 작업 상세 내용
-   Swagger 상 `Main Home (친구 둘러보기) 친구 찾기, 팔로우, 채팅 관련 API` 에 위치해 있던 팔로우 요청이
 `마이페이지 팔로우 한 친구 목록 보기 API`로 이동함에 따라 팔로우 요청 api의 `home`을 `mypage`로 수정하였습니다.
    - API URL 수정으로 백엔드 작업도 반영되어야 합니다. (빌드 및 배포가 FE, BE 모두 진행되어야 합니다.)
- Friend Status가 수정되었습니다.
    - **FRIEND**: 친구상태
    - **FOLLOWING**: 상대방에게 요청을 보낸 상태
    - **FOLLOWED**: 상대방으로부터 요청을 받은 상태
    - **NONE**: 어떤 액션도 이뤄지지 않은 상태
    - 이전 상태 값(PENDING, ACCEPTED, REJECTED)이 전달 될 것을 생각해 삭제하지 않았습니다.
- Friend Status에 따른 ui 변화는 현재 Find 탭과 프로필 모달에만 적용이 들어갔습니다.
    - mypage의 Friends List와 Follow List에서 친구 리스트를 관리하지만 Figma 기반으로 UI의 변화가 있을 예정이고
    - 두 페이지 모두 Status에 따른 조건 분기를 진행하고 있지 않습니다.
    - mypage 리팩토링 시 참고해주시면 감사하겠습니다! @hm1n 


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈
Closes #240 
