### PR TITLE
[Bug/275] 트렌딩 뉴스 description 잘리는 문제, 타임스탬프 잘못 찍히는 문제 해결

### DIFF
--- a/src/features/k-culture/components/TrendingNewsItem.tsx
+++ b/src/features/k-culture/components/TrendingNewsItem.tsx
@@ -41,14 +41,14 @@ const TrendingNewsItem = ({ item, index }: TrendingNewsItemProps) => {
         <RankBadge>{index + 1}</RankBadge>
       </NewsImageContainer>
 
-      <Description>
+      <NewsDescription>
         <Title numberOfLines={2}>{item.title}</Title>
         <BottomRow>
           <CategoryBadge>{item.type ?? 'K-News'}</CategoryBadge>
           <Dot>•</Dot>
           <DateText>{timeStampToAgo(item.ago)}</DateText>
         </BottomRow>
-      </Description>
+      </NewsDescription>
     </NewsItemContainer>
   );
 };
@@ -83,4 +83,9 @@ const RankBadge = styled.Text`
 
 const Title = styled(NewsTitle)`
   margin-top: 26px;
+`;
+
+const NewsDescription = styled(Description)`
+  flex: none; /* 높이 유지 */
+  min-height: 53px;
 `;

--- a/src/features/k-culture/utils/timeStampToAgo.ts
+++ b/src/features/k-culture/utils/timeStampToAgo.ts
@@ -1,5 +1,19 @@
 export const timeStampToAgo = (timestamp: number): string => {
-  if (!timestamp) return 'Unknown time ago';
+  // 데이터가 없거나 음수인 경우
+  if (timestamp === undefined || timestamp === null || timestamp < 0) return 'Today';
 
-  return timestamp === 0 ? 'Today' : `${timestamp} days ago`;
+  if (timestamp === 0) return 'Today';
+
+  if (timestamp < 7) {
+    return timestamp === 1 ? `${timestamp} day ago` : `${timestamp} days ago`;
+  } else if (timestamp < 30) {
+    const weeks = Math.floor(timestamp / 7);
+    return weeks === 1 ? '1 week ago' : `${weeks} weeks ago`;
+  } else if (timestamp < 365) {
+    const months = Math.floor(timestamp / 30);
+    return months === 1 ? '1 month ago' : `${months} months ago`;
+  } else {
+    const years = Math.floor(timestamp / 365);
+    return years === 1 ? '1 year ago' : `${years} years ago`;
+  }
 };


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-  트렌딩 뉴스 높이 잘리는 문제 해결 **<- 간헐적으로 잘려 보여서 여러번 테스트 부탁드립니다...!!**
- ago: 0 일 경우 Unknown time ago 로 찍히는 문제 해결

## 🔍 작업 상세 내용

#### 1️⃣ 트렌딩 뉴스 렌더링 시 description 부분 높이 잘리는 문제 해결
- description 부분에 min-height 추가
- flex: none 속성 추가해 높이 줄어들지 않도록 설정

#### 2️⃣  timeStampToAgo 함수 수정
- 데이터가 undefined, null일 때, 0일 때 처리 구분
- 업로드된 지 오래 지난 뉴스일 경우 날짜에 따라 표시 방법 구분 ex) 1 month ago, 1 year ago

## 🏞️ 스크린샷
<img width="250" alt="스크린샷 2026-01-08 오전 2 05 29" src="https://github.com/user-attachments/assets/c2649a3e-49c9-4cf1-9a90-1cd629c1e514" />



## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #이슈번호
