### PR TITLE
[hotfix/#277] CustomBottomSheet가 열리지 않는 문제 해결

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,7 +22,7 @@ import {
   PlusJakartaSans_700Bold_Italic,
 } from '@expo-google-fonts/plus-jakarta-sans';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { PortalProvider } from '@gorhom/portal';
+import { PortalHost, PortalProvider } from '@gorhom/portal';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useFonts } from 'expo-font';
 import { Stack, useNavigationContainerRef, usePathname, useRouter } from 'expo-router';
@@ -138,8 +138,8 @@ export default function RootLayout() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
           <SafeAreaProvider style={{ flex: 1, backgroundColor: theme.colors.primary.black }}>
-            <BottomSheetModalProvider>
-              <PortalProvider>
+            <PortalProvider>
+              <BottomSheetModalProvider>
                 <AppLayout>
                   <ProfileProvider>
                     {/* 모든 화면을 항상 선언하고, 실제 이동은 위의 useEffect가 담당합니다. */}
@@ -153,9 +153,10 @@ export default function RootLayout() {
                   {/* 커뮤니티 관련 모달 - 전역에서 사용, 로그인 상태에 따라 조건부 렌더링*/}
                   {isLoggedIn && <MoreBottomSheet />}
                   {isLoggedIn && <ReportModal />}
+                  <PortalHost name="dropdown" />
                 </AppLayout>
-              </PortalProvider>
-            </BottomSheetModalProvider>
+              </BottomSheetModalProvider>
+            </PortalProvider>
           </SafeAreaProvider>
         </ThemeProvider>
       </QueryClientProvider>

--- a/src/features/k-culture/components/SortDropdown.tsx
+++ b/src/features/k-culture/components/SortDropdown.tsx
@@ -39,7 +39,7 @@ const SortDropDown = ({ value, onPress }: SortDropDownProps) => {
       </SortContainer>
 
       {isOpen && (
-        <Portal>
+        <Portal hostName="dropdown">
           <TouchableWithoutFeedback onPress={() => setIsOpen(false)}>
             <Overlay />
           </TouchableWithoutFeedback>


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

앱 전체 CustomBottomSheet가 열리지 않는 문제를 해결했습니다.

## 🔍 작업 상세 내용

**❗️문제 원인**

`BottomSheetModal`은 내부적으로 `@gorhom/portal`을 사용하며,  렌더링 위치는 가장 가까운 `PortalProvider` 컨텍스트를 기준으로 결정됩니다.

최근 드롭다운 구현을 위해 추가적인 `PortalProvider`가 트리에 도입되면서 `BottomSheetModalProvider`가 참조하는 Portal 컨텍스트가 기존과 달라지게 되었고, CustomBottomSheet가 화면에 렌더링되지 않는 문제가 발생했습니다.

<br/>

**🛠️ 해결 방법**

먼저 `PortalProvider`의 위치를 `BottomSheetModalProvider`보다 상위로 이동시켰습니다.

Provider의 순서를 변경하니 모달은 잘 렌더링 되었지만, 드롭다운이 렌더링되지 않는 문제가 생겼습니다.
따라서 드롭다운은 `PortalHost`를 사용하고 hostName을 명시적으로 지정하여 BottomSheet와 충돌 없이 별도의 렌더링 타겟을 사용하도록 분리했습니다.

```tsx
...
          {/* PortalProvider를 BottomSheetModalProvider보다 상위에 위치 */}
           <PortalProvider>
              <BottomSheetModalProvider>
                <AppLayout>
                  <ProfileProvider>
                    <Stack screenOptions={{ headerShown: false }}>
                      <Stack.Screen name="(tabs)" />
                      <Stack.Screen name="(auth)" />
                      <Stack.Screen name="+not-found" />
                    </Stack>
                    <Toast config={toastConfig} topOffset={80} />
                  </ProfileProvider>
                  {isLoggedIn && <MoreBottomSheet />}
                  {isLoggedIn && <ReportModal />}
                  {/* portalhost로 dropdown 렌더링 레이어 명시 */}
                  <PortalHost name="dropdown" /> 
                </AppLayout>
              </BottomSheetModalProvider>
            </PortalProvider>
```

> app/_layout.tsx

<br/>

⚠️ 참고 사항

`@gorhom/bottom-sheet`는 내부적으로 `@gorhom/portal`에 의존하므로 `PortalProvider`를 중복으로 사용할 경우 컨텍스트 분리에 주의가 필요합니다.

PortalHost는 Stack보다 하단에 위치해 있어야 Stack에 가려지지 않고 Stack 위로 렌더링됩니다. _(Stack 상단에 위치할 경우 드롭다운이 보이지 않습니다)_ 순서에 유의해주세요!

<br/>

## 🏞️ 스크린샷

X

## ✅ 체크리스트

-   [x] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [x] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [x] 불필요한 console.log, 주석을 제거했나요?
-   [x] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #277