### PR TITLE
[Hotfix/#284] 친구 상태에 따른 ui와 로직 수정

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { LinkedSpaceRecommendModal } from '@/src/features/find/components/Linked
 import { useLinkedSpaceRecommendModal } from '@/src/features/find/hooks/useLinkedSpaceRecommendModal';
 import { useRecommendedFriends } from '@/src/features/find/hooks/useRecommendedFriends';
 import UserProfileCard from '@/src/shared/components/UserProfileCard';
-import { useCancelFollowUserMutation, useFollowUserMutation } from '@/src/shared/hooks/useUserProfileQuery';
+import { useCancelFollowUserMutation, useFollowUserMutation } from '@/src/shared/hooks/useFollowQuery';
 import { Text } from '@react-navigation/elements';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect, useRef, useState } from 'react';

--- a/app/(tabs)/mypage/follows/index.tsx
+++ b/app/(tabs)/mypage/follows/index.tsx
@@ -5,6 +5,7 @@ import useDeclineFollow from '@/hooks/mutations/useDeclineFollow';
 import { useFollowList } from '@/hooks/queries/useFollowList';
 import { useCreateOneToOneRoom } from '@/src/features/chat/room/hooks/useCreateOneToOneRoom';
 import UserProfileCard from '@/src/shared/components/UserProfileCard';
+import { useCancelFollowUserMutation } from '@/src/shared/hooks/useFollowQuery';
 import { User } from '@/src/shared/types/user';
 import { theme } from '@/src/styles/theme';
 import { router } from 'expo-router';
@@ -51,6 +52,8 @@ export default function FollowListScreen() {
     isError: errorSent,
     refetch: refetchSent,
   } = useFollowList('PENDING', 'sent');
+
+  const cancelFollowUserMutation = useCancelFollowUserMutation();
 
   const createChatRoom = useCreateOneToOneRoom();
 
@@ -261,7 +264,9 @@ export default function FollowListScreen() {
                     actions={{
                       secondary: {
                         label: 'Pending',
-                        onPress: () => {},
+                        onPress: () => {
+                          cancelFollowUserMutation.mutate(item.userId);
+                        },
                         loading: inFlight.has(item.userId),
                       },
                       chat: {

--- a/app/(tabs)/mypage/friends/index.tsx
+++ b/app/(tabs)/mypage/friends/index.tsx
@@ -1,7 +1,7 @@
 import Icon from '@/components/common/Icon';
-import useUnfollowAccepted from '@/hooks/mutations/useUnfollowAccepted'; // ✅ 변경
 import { useAcceptedFollowing } from '@/hooks/queries/useFollowing';
 import UserProfileCard from '@/src/shared/components/UserProfileCard';
+import { useUnfollowUserMutation } from '@/src/shared/hooks/useFollowQuery';
 
 import { useCreateOneToOneRoom } from '@/src/features/chat/room/hooks/useCreateOneToOneRoom';
 import { theme } from '@/src/styles/theme';
@@ -21,7 +21,7 @@ export default function FriendsOnlyScreen() {
   const [page, setPage] = useState(1);
   const listRef = useRef<import('react-native').FlatList>(null);
 
-  const unfollowMutation = useUnfollowAccepted(); // ✅ 변경
+  const unfollowMutation = useUnfollowUserMutation();
 
   const confirmUnfollow = (userId: number) => {
     Alert.alert(

--- a/app/(tabs)/mypage/friends/index.tsx
+++ b/app/(tabs)/mypage/friends/index.tsx
@@ -67,7 +67,7 @@ export default function FriendsOnlyScreen() {
       <HList
         ref={listRef}
         data={data}
-        keyExtractor={(item) => String(item.id)}
+        keyExtractor={(item) => String(item.userId)}
         horizontal
         pagingEnabled
         decelerationRate="fast"
@@ -94,7 +94,7 @@ export default function FriendsOnlyScreen() {
                 actions={{
                   primary: {
                     label: 'Unfollow',
-                    onPress: () => confirmUnfollow(item.id),
+                    onPress: () => confirmUnfollow(item.userId),
                   },
                   chat: {
                     label: 'Chat',

--- a/src/shared/api/follow.ts
+++ b/src/shared/api/follow.ts
@@ -17,3 +17,15 @@ export const cancelFollowUser = async (userId: number) => {
   const response = await api.delete(`/api/v1/mypage/users/follow/${userId}`);
   return response.data;
 };
+
+/** 팔로우 요청 수락 */
+export const acceptFollowUser = async (userId: number) => {
+  const response = await api.patch(`/api/v1/mypage/accept-follow/${userId}`);
+  return response.data;
+};
+
+/** 팔로우 요청 거절 */
+export const declineFollowUser = async (userId: number) => {
+  const response = await await api.delete(`/api/v1/mypage/decline-follow/${userId}`);
+  return response.data;
+};

--- a/src/shared/api/follow.ts
+++ b/src/shared/api/follow.ts
@@ -1,0 +1,19 @@
+import api from '@/api/axiosInstance';
+
+/** 사용자 팔로우 */
+export const followUser = async (userId: number) => {
+  const response = await api.post(`/api/v1/mypage/follow/${userId}`);
+  return response.data;
+};
+
+/** 사용자 언팔로우 */
+export const unfollowUser = async (userId: number) => {
+  const response = await api.delete(`/api/v1/mypage/users/follow/accepted/${userId}`);
+  return response.data;
+};
+
+/** 상대에게 요청한 팔로우(FOLLOWING 상태) 취소 */
+export const cancelFollowUser = async (userId: number) => {
+  const response = await api.delete(`/api/v1/mypage/users/follow/${userId}`);
+  return response.data;
+};

--- a/src/shared/api/userProfile.ts
+++ b/src/shared/api/userProfile.ts
@@ -6,21 +6,3 @@ export const fetchUserProfile = async (userId: number): Promise<User> => {
   const response = await api.get(`/api/v1/member/${userId}/info`);
   return response.data;
 };
-
-/** 사용자 팔로우 */
-export const followUser = async (userId: number) => {
-  const response = await api.post(`/api/v1/mypage/follow/${userId}`);
-  return response.data;
-};
-
-/** 사용자 언팔로우 */
-export const unfollowUser = async (userId: number) => {
-  const response = await api.delete(`/api/v1/mypage/users/follow/accepted/${userId}`);
-  return response.data;
-};
-
-/** 사용자 팔로우 취소 */
-export const cancelFollowUser = async (userId: number) => {
-  const response = await api.delete(`/api/v1/mypage/users/follow/${userId}`);
-  return response.data;
-};

--- a/src/shared/api/userProfile.ts
+++ b/src/shared/api/userProfile.ts
@@ -15,7 +15,7 @@ export const followUser = async (userId: number) => {
 
 /** 사용자 언팔로우 */
 export const unfollowUser = async (userId: number) => {
-  const response = await api.delete(`/api/v1/mypage/follow/${userId}`);
+  const response = await api.delete(`/api/v1/mypage/users/follow/accepted/${userId}`);
   return response.data;
 };
 

--- a/src/shared/components/ProfileModal.tsx
+++ b/src/shared/components/ProfileModal.tsx
@@ -4,7 +4,7 @@ import {
   useCancelFollowUserMutation,
   useFollowUserMutation,
   useUnfollowUserMutation,
-} from '@/src/shared/hooks/useUserProfileQuery';
+} from '@/src/shared/hooks/useFollowQuery';
 import React from 'react';
 import { ActivityIndicator, Modal, ScrollView } from 'react-native';
 import styled from 'styled-components/native';
@@ -69,11 +69,10 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
               <UserProfileCard
                 user={userData}
                 defaultExpanded={true}
-                // BE 작업 동기화를 위해 이전 상태(ACCEPTED, PENDING) 유지
                 actions={{
-                  ...(userData.followStatus === 'ACCEPTED' || userData.followStatus === 'FRIEND'
+                  ...(userData.followStatus === 'FOLLOWED'
                     ? { decline: { label: 'Unfollow', onPress: handleUnfollow } }
-                    : userData.followStatus === 'PENDING' || userData.followStatus === 'FOLLOWING'
+                    : userData.followStatus === 'FOLLOWING'
                       ? { secondary: { label: 'Pending', onPress: handleCancelFollow } }
                       : { primary: { label: 'Follow', onPress: handleFollow } }),
                   chat: { label: 'Chat', onPress: handleChat },

--- a/src/shared/components/ProfileModal.tsx
+++ b/src/shared/components/ProfileModal.tsx
@@ -1,6 +1,7 @@
 import { useCreateOneToOneRoom } from '@/src/features/chat/room/hooks/useCreateOneToOneRoom';
 import UserProfileCard from '@/src/shared/components/UserProfileCard';
 import {
+  useAcceptFollowUserMutation,
   useCancelFollowUserMutation,
   useFollowUserMutation,
   useUnfollowUserMutation,
@@ -32,6 +33,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
   const followUserMutation = useFollowUserMutation();
   const unfollowUserMutation = useUnfollowUserMutation();
   const cancelFollowUserMutation = useCancelFollowUserMutation();
+  const acceptFollowUserMutation = useAcceptFollowUserMutation();
   const createChatRoom = useCreateOneToOneRoom();
 
   const handleFollow = () => {
@@ -47,6 +49,11 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
   const handleCancelFollow = () => {
     if (!userData) return;
     cancelFollowUserMutation.mutate(userData.userId);
+  };
+
+  const handleAcceptFollow = () => {
+    if (!userData) return;
+    acceptFollowUserMutation.mutate(userData.userId);
   };
 
   const handleChat = () => {
@@ -70,11 +77,13 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
                 user={userData}
                 defaultExpanded={true}
                 actions={{
-                  ...(userData.followStatus === 'FOLLOWED'
+                  ...(userData.followStatus === 'FRIEND'
                     ? { decline: { label: 'Unfollow', onPress: handleUnfollow } }
                     : userData.followStatus === 'FOLLOWING'
                       ? { secondary: { label: 'Pending', onPress: handleCancelFollow } }
-                      : { primary: { label: 'Follow', onPress: handleFollow } }),
+                      : userData.followStatus === 'FOLLOWED'
+                        ? { primary: { label: 'Accept', onPress: handleAcceptFollow } }
+                        : { primary: { label: 'Follow', onPress: handleFollow } }),
                   chat: { label: 'Chat', onPress: handleChat },
                 }}
               />

--- a/src/shared/hooks/useFollowQuery.ts
+++ b/src/shared/hooks/useFollowQuery.ts
@@ -1,4 +1,10 @@
-import { cancelFollowUser, followUser, unfollowUser } from '@/src/shared/api/follow';
+import {
+  acceptFollowUser,
+  cancelFollowUser,
+  declineFollowUser,
+  followUser,
+  unfollowUser,
+} from '@/src/shared/api/follow';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { USER_PROFILE_QK } from './useUserProfileQuery';
 
@@ -43,6 +49,41 @@ export const useCancelFollowUserMutation = () => {
       qc.invalidateQueries({ queryKey: USER_PROFILE_QK(userId) });
       // 팔로우 요청 목록 캐시 무효화
       qc.invalidateQueries({ queryKey: ['follow-list', 'PENDING', 'sent'] });
+    },
+  });
+};
+
+/** 팔로우 수락 Mutation */
+export const useAcceptFollowUserMutation = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => acceptFollowUser(userId),
+    onSuccess: async (_, userId) => {
+      // 해당 사용자 프로필 캐시 무효화
+      // 팔로우 요청 목록 캐시 무효화, 친구 목록 캐시 무효화
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: USER_PROFILE_QK(userId) }),
+        qc.invalidateQueries({ queryKey: ['follow-list', 'PENDING', 'received'] }),
+        qc.invalidateQueries({ queryKey: ['following', 'ACCEPTED'] }),
+      ]);
+    },
+  });
+};
+
+/** 팔로우 거절 Mutation */
+export const useDeclineFollowUserMutation = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => declineFollowUser(userId),
+    onSuccess: async (_, userId) => {
+      // 해당 사용자 프로필 캐시 무효화
+      // 팔로우 요청 목록 캐시 무효화
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: USER_PROFILE_QK(userId) }),
+        qc.invalidateQueries({ queryKey: ['follow-list', 'PENDING', 'received'] }),
+      ]);
     },
   });
 };

--- a/src/shared/hooks/useFollowQuery.ts
+++ b/src/shared/hooks/useFollowQuery.ts
@@ -1,0 +1,48 @@
+import { cancelFollowUser, followUser, unfollowUser } from '@/src/shared/api/follow';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { USER_PROFILE_QK } from './useUserProfileQuery';
+
+/** 팔로우 Mutation */
+export const useFollowUserMutation = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => followUser(userId),
+    onSuccess: (_, userId) => {
+      // 해당 사용자 프로필 캐시 무효화
+      qc.invalidateQueries({ queryKey: USER_PROFILE_QK(userId) });
+      // 팔로우 요청 목록 캐시 무효화
+      qc.invalidateQueries({ queryKey: ['follow-list', 'PENDING', 'sent'] });
+    },
+  });
+};
+
+/** 언팔로우 Mutation */
+export const useUnfollowUserMutation = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => unfollowUser(userId),
+    onSuccess: (_, userId) => {
+      // 해당 사용자 프로필 캐시 무효화
+      qc.invalidateQueries({ queryKey: USER_PROFILE_QK(userId) });
+      // 친구 목록 캐시 무효화
+      qc.invalidateQueries({ queryKey: ['following', 'ACCEPTED'] });
+    },
+  });
+};
+
+/** 팔로우 취소 Mutation */
+export const useCancelFollowUserMutation = () => {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => cancelFollowUser(userId),
+    onSuccess: (_, userId) => {
+      // 해당 사용자 프로필 캐시 무효화
+      qc.invalidateQueries({ queryKey: USER_PROFILE_QK(userId) });
+      // 팔로우 요청 목록 캐시 무효화
+      qc.invalidateQueries({ queryKey: ['follow-list', 'PENDING', 'sent'] });
+    },
+  });
+};

--- a/src/shared/hooks/useUserProfileQuery.ts
+++ b/src/shared/hooks/useUserProfileQuery.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { cancelFollowUser, fetchUserProfile, followUser, unfollowUser } from '../api/userProfile';
+import { useQuery } from '@tanstack/react-query';
+import { fetchUserProfile } from '../api/userProfile';
 
 /** 쿼리 키 */
 export const USER_PROFILE_QK = (userId: number) => ['chat', 'userProfile', userId] as const;
@@ -10,52 +10,7 @@ export const useUserProfileQuery = (userId: number | null) => {
     queryKey: USER_PROFILE_QK(userId!),
     queryFn: () => fetchUserProfile(userId!),
     enabled: !!userId,
-    staleTime: 5 * 60_000, // 5분
+    staleTime: 0,
     gcTime: 10 * 60_000, // 10분
-  });
-};
-
-/** 팔로우 Mutation */
-export const useFollowUserMutation = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (userId: number) => followUser(userId),
-    onSuccess: (_, userId) => {
-      // 해당 사용자 프로필 캐시 무효화
-      queryClient.invalidateQueries({
-        queryKey: USER_PROFILE_QK(userId),
-      });
-    },
-  });
-};
-
-/** 언팔로우 Mutation */
-export const useUnfollowUserMutation = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (userId: number) => unfollowUser(userId),
-    onSuccess: (_, userId) => {
-      // 해당 사용자 프로필 캐시 무효화
-      queryClient.invalidateQueries({
-        queryKey: USER_PROFILE_QK(userId),
-      });
-    },
-  });
-};
-
-/** 팔로우 취소 Mutation */
-export const useCancelFollowUserMutation = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (userId: number) => cancelFollowUser(userId),
-    onSuccess: (_, userId) => {
-      // 해당 사용자 프로필 캐시 무효화
-      queryClient.invalidateQueries({
-        queryKey: USER_PROFILE_QK(userId),
-      });
-    },
   });
 };


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

- 친구 리스트 페이지에서 나타나던 undefined에러를 해결하였습니다.
- 사용자 언팔로우가 진행되지 않던 문제를 fix 했습니다.
- 팔로우 관련 api 및 hook(query)를 추가하였습니다.

## 🔍 작업 상세 내용
> 친구 상태 정의는 이전 pr을 참고해주세요 #264 
-  필드명이 id로 잡혀 있어 api 응답값인 userId로 수정하여 undefined 에러를 해결하였습니다.
- 사용자 언팔로우 api 경로가 잘못되어 올바른 경로로 수정하였습니다.
- 팔로우 관련 api는 총 5개로 해당 로직을 `src/shared/api/follow.ts` 및 `src/shared/hooks/useFollowQuery.ts`에 반영하였습니다.
  - 팔로우 요청 (followStatus: NONE)
  - 팔로우 요청 취소 (followStatus: FOLLOWING)
  - 언팔로우 (followStatus: FRIEND)
  - 팔로우 요청 수락 (followStatus: FOLLOWED)
  - 팔로우 요청 거절 (followStatus: FOLLOWED)
- 프로필 모달 클릭 시 followStatus를 반영하여 올바른 버튼의 렌더링, 로직이 수행될 수 있도록 수정하였습니다.
```js
<UserProfileCard
  user={userData}
  defaultExpanded={true}
  actions={{
    ...(userData.followStatus === 'FRIEND'
      ? { decline: { label: 'Unfollow', onPress: handleUnfollow } }
      : userData.followStatus === 'FOLLOWING'
        ? { secondary: { label: 'Pending', onPress: handleCancelFollow } }
        : userData.followStatus === 'FOLLOWED'
          ? { primary: { label: 'Accept', onPress: handleAcceptFollow } }
          : { primary: { label: 'Follow', onPress: handleFollow } }),
    chat: { label: 'Chat', onPress: handleChat },
  }}
/>
```

#### 추가 제언
팔로잉/팔로워 페이지의 경우 `GET /api/v1/mypage/follows` api를 통해 데이터를 수신받습니다.
다만, api 응답 필드 중 `friendType`은 현재 FE에서 사용하고 있지 않습니다.(팔로잉/팔로워의 구분은 api 호출시의 파라미터가 결정합니다.)
추가로 api 호출에 필요한 파라미터의 값이 이전 상태값(ACCEPTED, PENDING, REJECTED)을 사용중이기에 다음을 제안합니다.
1. friendType > followStatus로의 필드명 통합
2. api 호출의 파라미터 제거(팔로잉/팔로워 구분은 api 응답 필드의 followStatus로 구분)

> 해당 사항은 담당인 @usingjun 님께 전달드린 상태고 추후 마이페이지>친구 관련 페이지 리팩토링 시 참고하면 좋을 것 같아 남깁니다. @hm1n 

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #284 
