### PR TITLE
[hotfix/#291] 메시지 삭제, 링크드스페이스 멤버 표현 수정

### DIFF
--- a/app/chat/[roomId]/index.tsx
+++ b/app/chat/[roomId]/index.tsx
@@ -13,8 +13,8 @@ import { CHAT_MEMBER_ROUTE } from '@/src/shared/constants/route';
 import { useUserProfileQuery } from '@/src/shared/hooks/useUserProfileQuery';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
-import React, { useEffect, useState } from 'react';
-import { KeyboardAvoidingView, Platform, StatusBar } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { FlatList, KeyboardAvoidingView, Platform, StatusBar } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
@@ -24,11 +24,15 @@ const ChattingRoomScreen = () => {
   const insets = useSafeAreaInsets();
   const { roomId, roomName } = useLocalSearchParams<{ roomId: string; roomName: string }>();
   const [myUserId, setMyUserId] = useState<string>('');
+  const flatListRef = useRef<FlatList>(null);
 
   // ----------- hooks ----------- //
   const { loadMessages } = useChatMessages(roomId);
-  const messageActions = useMessageActions();
-  const messageSearch = useMessageSearch(roomId);
+  const messageSearch = useMessageSearch({ roomId, flatListRef });
+  const messageActions = useMessageActions({
+    flatListRef,
+    myUserId,
+  });
 
   // ----------- profile modal ----------- //
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
@@ -80,7 +84,7 @@ const ChattingRoomScreen = () => {
               onLoadMore={loadMessages}
               onDeleteMessage={messageActions.deleteMessageWithConfirm}
               onProfilePress={handleProfilePress}
-              flatListRef={messageSearch.flatListRef}
+              flatListRef={flatListRef}
             />
 
             {/* 하단 입력창 또는 검색 내비게이션 */}

--- a/src/features/chat/room/hooks/useChatMessages.ts
+++ b/src/features/chat/room/hooks/useChatMessages.ts
@@ -121,7 +121,7 @@ export const useChatMessages = (roomId: string): ChatMessagesHook => {
 
         // 메시지 삭제 구독
         unsubscribeDeletes = stompConnection.subscribe(`/topic/rooms/${roomId}`, (data: any) => {
-          if (data.type === 'delete') {
+          if (data.type === 'MESSAGE_DELETE') {
             removeMessage(Number(data.id));
           }
         });

--- a/src/features/chat/room/hooks/useMessageActions.ts
+++ b/src/features/chat/room/hooks/useMessageActions.ts
@@ -1,8 +1,7 @@
-// src/features/chat/room/hooks/useMessageActions.ts
 import { useStompStore } from '@/src/store/useStompStore';
 import * as SecureStore from 'expo-secure-store';
-import { useCallback } from 'react';
-import { Alert } from 'react-native';
+import { useCallback, useEffect, useRef } from 'react';
+import { Alert, FlatList } from 'react-native';
 import { useChatStore } from '../stores/useChatStore';
 
 interface MessageActionsHook {
@@ -10,11 +9,31 @@ interface MessageActionsHook {
   deleteMessageWithConfirm: (messageId: number) => void;
 }
 
-export const useMessageActions = (): MessageActionsHook => {
+interface MessageActionsParams {
+  flatListRef?: React.RefObject<FlatList | null>;
+  myUserId: string;
+}
+
+export const useMessageActions = ({ flatListRef, myUserId }: MessageActionsParams): MessageActionsHook => {
   // Store에서 필요한 액션 가져오기
   const stompConnection = useStompStore((state) => state);
   const clearCurrentMessage = useChatStore((state) => state.clearCurrentMessage);
   const getCurrentMessage = () => useChatStore.getState().currentMessage;
+  const messages = useChatStore((state) => state.messages);
+  const shouldScrollRef = useRef(false);
+
+  // 내가 보낸 메시지가 추가되었을 때 스크롤
+  useEffect(() => {
+    if (shouldScrollRef.current && messages.length > 0) {
+      const latestMessage = messages[0];
+      if (latestMessage.senderId.toString() === myUserId) {
+        requestAnimationFrame(() => {
+          flatListRef?.current?.scrollToOffset({ offset: 0, animated: true });
+        });
+      }
+      shouldScrollRef.current = false;
+    }
+  }, [messages, myUserId, flatListRef]);
 
   /** 메시지 전송 */
   const sendMessage = useCallback(
@@ -37,6 +56,9 @@ export const useMessageActions = (): MessageActionsHook => {
           senderId: myUserId,
           content: currentMessage.trim(),
         };
+
+        // 메시지 전송 전에 스크롤 플래그 설정
+        shouldScrollRef.current = true;
 
         await stompConnection.publish('/app/chat.sendMessage', body);
 

--- a/src/features/chat/room/hooks/useMessageSearch.ts
+++ b/src/features/chat/room/hooks/useMessageSearch.ts
@@ -1,5 +1,5 @@
 // src/features/chat/room/hooks/useMessageSearch.ts
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { FlatList } from 'react-native';
 import { loadMessagesAroundAPI, searchMessagesAPI } from '../api/messages';
 import { useChatStore } from '../stores/useChatStore';
@@ -16,7 +16,6 @@ interface MessageSearchHook {
     totalCount: number;
     error: Error | null;
   };
-  flatListRef: React.RefObject<FlatList | null>;
   toggleSearch: () => void;
   setSearchText: (text: string) => void;
   performSearch: () => Promise<void>;
@@ -26,7 +25,12 @@ interface MessageSearchHook {
   isCurrentMessage: (messageId: number) => boolean;
 }
 
-export const useMessageSearch = (roomId: string): MessageSearchHook => {
+interface MessageSearchParams {
+  roomId: string;
+  flatListRef: React.RefObject<FlatList | null>;
+}
+
+export const useMessageSearch = ({ roomId, flatListRef }: MessageSearchParams): MessageSearchHook => {
   // Store에서 상태와 액션 가져오기
 
   const mergeMessages = useChatStore((state) => state.mergeMessages);
@@ -47,8 +51,6 @@ export const useMessageSearch = (roomId: string): MessageSearchHook => {
     setError,
     clearSearch,
   } = useSearchStore();
-
-  const flatListRef = useRef<FlatList>(null);
 
   /**
    * 메시지로 스크롤하는 내부 함수
@@ -157,7 +159,6 @@ export const useMessageSearch = (roomId: string): MessageSearchHook => {
       totalCount,
       error,
     },
-    flatListRef,
     toggleSearch,
     setSearchText,
     performSearch,

--- a/src/features/chat/room/hooks/useMessageSearch.ts
+++ b/src/features/chat/room/hooks/useMessageSearch.ts
@@ -1,5 +1,5 @@
 // src/features/chat/room/hooks/useMessageSearch.ts
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { FlatList } from 'react-native';
 import { loadMessagesAroundAPI, searchMessagesAPI } from '../api/messages';
 import { useChatStore } from '../stores/useChatStore';
@@ -21,7 +21,6 @@ interface MessageSearchHook {
   performSearch: () => Promise<void>;
   navigateToUp: () => void;
   navigateToDown: () => void;
-  clearSearch: () => void;
   isCurrentMessage: (messageId: number) => boolean;
 }
 
@@ -49,8 +48,15 @@ export const useMessageSearch = ({ roomId, flatListRef }: MessageSearchParams): 
     incrementIndex,
     decrementIndex,
     setError,
-    clearSearch,
+    deactivateSearch,
   } = useSearchStore();
+
+  // 컴포넌트 언마운트 시 검색 상태 초기화
+  useEffect(() => {
+    return () => {
+      deactivateSearch();
+    };
+  }, [deactivateSearch]);
 
   /**
    * 메시지로 스크롤하는 내부 함수
@@ -164,7 +170,6 @@ export const useMessageSearch = ({ roomId, flatListRef }: MessageSearchParams): 
     performSearch,
     navigateToUp,
     navigateToDown,
-    clearSearch,
     isCurrentMessage,
   };
 };

--- a/src/features/linked-space/detail/components/ParticipantsInfo.tsx
+++ b/src/features/linked-space/detail/components/ParticipantsInfo.tsx
@@ -45,7 +45,9 @@ export const ParticipantsInfo = ({ participantCount, participantsImageUrls }: Pa
             )}
           />
         </ParticipantsImagesBox>
-        <ParticipantsTotalText>+{participantCount - 5}</ParticipantsTotalText>
+        <ParticipantsTotalText>
+          {participantCount - 5 <= 0 ? participantCount : `+${participantCount - 5}`}
+        </ParticipantsTotalText>
       </ParticipantsImageContainer>
     </ParticipantsContainer>
   );

--- a/src/features/linked-space/detail/components/ParticipantsInfo.tsx
+++ b/src/features/linked-space/detail/components/ParticipantsInfo.tsx
@@ -45,9 +45,7 @@ export const ParticipantsInfo = ({ participantCount, participantsImageUrls }: Pa
             )}
           />
         </ParticipantsImagesBox>
-        <ParticipantsTotalText>
-          {participantCount - 5 <= 0 ? participantCount : `+${participantCount - 5}`}
-        </ParticipantsTotalText>
+        <ParticipantsTotalText>{participantCount - 5 > 0 ? `+${participantCount - 5}` : ''}</ParticipantsTotalText>
       </ParticipantsImageContainer>
     </ParticipantsContainer>
   );


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-  메시지와 링크드스페이스 error fix
- 메시지 전송 시 최하단 스크롤 기능 추가

## 🔍 작업 상세 내용
-  메시지 삭제에 대한 소켓 타입을 BE 응답값과 동기화 하였습니다.
- 링크드스페이스 디테일 페이지에서 멤버 수가 음수로 표현되던 문제를 fix하였습니다.
  -   ```{participantCount - 5 > 0 ? `+${participantCount - 5}` : ''}```
  - 기존의 단순 '-' 연산을 멤버수가 5명 이상일 경우에 해당하는 조건을 추가하였습니다. 
  - 5명 이하일 경우 멤버 이미지 우측 인원 수가 나타나지 않도록 했습니다.
- useMessageActions.ts에 메시지 전송 시 최하단 스크롤 로직을 추가하였습니다.
  - 기존 스크롤을 제어하기 위한 FlatListRef를 useMessageSearch.ts에서 index.ts로 소유권을 이전, 
  필요한 hook에 주입하는 방식으로 전환하였습니다.
- 검색 상태 활성화가 초기화 되지 않는 문제를 인지하고 useSearchStore를 사용하는 useMessageSearch.ts에서 언마운트 시 Store 정보를 초기화하는 로직을 추가하였습니다.

## 🏞️ 스크린샷
https://github.com/user-attachments/assets/e957283d-6b37-4c86-806e-e1a4544999ad


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #291 
