### PR TITLE
[Feat/#304] 뉴스 카테고리를 서버 동기화 방식으로 변경

### DIFF
--- a/src/features/k-culture/apis/news.ts
+++ b/src/features/k-culture/apis/news.ts
@@ -31,3 +31,9 @@ export const getKNews = async (type: NewsType, params: NewsPageParams) => {
   });
   return res.data;
 };
+
+// 뉴스 카테고리 조회
+export const getNewsCategories = async () => {
+  const res = await api.get(`/api/v2/main-contents/categories`);
+  return res.data.data;
+};

--- a/src/features/k-culture/apis/news.ts
+++ b/src/features/k-culture/apis/news.ts
@@ -1,5 +1,5 @@
 import api from '@/api/axiosInstance';
-import { NewsPageParams, NewsType } from '../types';
+import { NewsPageParams } from '../types';
 
 export const getNewsDetail = async (contentId: number) => {
   const res = await api.get(`/api/v2/main-contents/${contentId}`);
@@ -7,7 +7,7 @@ export const getNewsDetail = async (contentId: number) => {
 };
 
 // 메인페이지용 최근 K-컬처 뉴스 3개 조회
-export const getRecentThreeNews = async (type: NewsType) => {
+export const getRecentThreeNews = async (type: string) => {
   const res = await api.get(`/api/v2/main-contents/${type}/preview`);
   return res.data;
 };
@@ -19,7 +19,7 @@ export const getTrendingNews = async () => {
 };
 
 // k-news 리스트 조회 (무한 스크롤용, cursor 기반)
-export const getKNews = async (type: NewsType, params: NewsPageParams) => {
+export const getKNews = async (type: string, params: NewsPageParams) => {
   const { sort, size = 20, cursor } = params;
 
   const res = await api.get(`/api/v2/main-contents/${type}/list`, {

--- a/src/features/k-culture/components/MainPageKNews.tsx
+++ b/src/features/k-culture/components/MainPageKNews.tsx
@@ -7,16 +7,15 @@ import styled from 'styled-components/native';
 import { ErrorContainer, ErrorText, RetryButton, RetryButtonText } from '../../community/shared/styles/styles';
 import { useGetRecentKnews } from '../hooks/useGetRecentKnews';
 import { EmptyListContainer, EmptyListText } from '../styles/styles';
-import { NewsType } from '../types';
 import KNewsItem from './KNewsItem';
 import MoreButton from './MoreButton';
 import NewsCategory from './NewsCategory';
 
 const MainPageKNews = () => {
-  const [selectedCategory, setSelectedCategory] = useState<NewsType>('K-POP');
+  const [selectedCategory, setSelectedCategory] = useState<string>('K-POP');
   const { items, isError, refetch, isLoading } = useGetRecentKnews(selectedCategory);
 
-  const handleCategoryPress = (category: NewsType) => {
+  const handleCategoryPress = (category: string) => {
     setSelectedCategory(category);
   };
 

--- a/src/features/k-culture/components/NewsCategory.tsx
+++ b/src/features/k-culture/components/NewsCategory.tsx
@@ -1,26 +1,27 @@
 import { textStyle, theme } from '@/src/styles/theme';
 import React from 'react';
 import styled from 'styled-components/native';
-import { NEWS_CATEGORIES, NEWS_CATEGORY_MAPPER } from '../constants/categoryMapper';
-import { NewsType } from '../types';
+import { useGetNewsCategories } from '../hooks/useGetNewsCategories';
 
 type NewsCategoryProps = {
-  value: NewsType;
-  onPress: (category: NewsType) => void;
+  value: string;
+  onPress: (category: string) => void;
 };
 
 const NewsCategory = ({ value, onPress }: NewsCategoryProps) => {
+  const { data: categories } = useGetNewsCategories();
+
   return (
     <Container
       horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={{ gap: 6, paddingHorizontal: 20 }}
     >
-      {NEWS_CATEGORIES.map((key) => {
-        const isActive = value === key;
+      {categories?.map(({ code, name }) => {
+        const isActive = value === code;
         return (
-          <CategoryButton key={key} active={isActive} onPress={() => onPress(key)}>
-            <CategoryButtonText active={isActive}>{NEWS_CATEGORY_MAPPER[key]}</CategoryButtonText>
+          <CategoryButton key={code} active={isActive} onPress={() => onPress(code)}>
+            <CategoryButtonText active={isActive}>{name}</CategoryButtonText>
           </CategoryButton>
         );
       })}

--- a/src/features/k-culture/constants/categoryMapper.ts
+++ b/src/features/k-culture/constants/categoryMapper.ts
@@ -1,15 +1,3 @@
-import { NewsType } from '../types';
-
-export const NEWS_CATEGORY_MAPPER = {
-  'K-POP': '🎧K-POP',
-  'K-DRAMA': '💖K-Drama',
-  'K-BEAUTY': '💄K-Beauty',
-  'K-FASHION': '🧢K-Fashion',
-  'K-CULTURE': '🇰🇷K-Culture',
-} as const;
-
-export const NEWS_CATEGORIES = Object.keys(NEWS_CATEGORY_MAPPER) as NewsType[];
-
 export const NEWS_SORT_MAPPER = {
   TRENDING: 'Trending',
   NEW: 'New',

--- a/src/features/k-culture/hooks/useGetNewsCategories.ts
+++ b/src/features/k-culture/hooks/useGetNewsCategories.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getNewsCategories } from '../apis/news';
+import { NewsCategory } from '../types';
+
+export const useGetNewsCategories = () => {
+  return useQuery<NewsCategory[]>({
+    queryKey: ['news', 'categories'],
+    queryFn: () => getNewsCategories(),
+    staleTime: 1000 * 60 * 60, // 1시간동안은 다시 조회하지 않음
+  });
+};

--- a/src/features/k-culture/hooks/useGetRecentKnews.ts
+++ b/src/features/k-culture/hooks/useGetRecentKnews.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { KNewsItemType, KNewsResp, NewsType } from '../types';
+import { KNewsItemType, KNewsResp } from '../types';
 import { getRecentThreeNews } from './../apis/news';
 
-export const useGetRecentKnews = (category: NewsType) => {
+export const useGetRecentKnews = (category: string) => {
   const query = useQuery<KNewsResp>({
     queryKey: ['news', 'recentKnews', category],
     queryFn: () => getRecentThreeNews(category),

--- a/src/features/k-culture/types/index.ts
+++ b/src/features/k-culture/types/index.ts
@@ -1,6 +1,3 @@
-import { NEWS_CATEGORY_MAPPER } from '../constants/categoryMapper';
-
-export type NewsType = keyof typeof NEWS_CATEGORY_MAPPER;
 export type NewsSortType = 'TRENDING' | 'NEW';
 
 // 뉴스 상세 아이템 타입
@@ -15,7 +12,7 @@ export interface KCultureNewsItem {
 export interface NewsPreviewItem {
   contentId: number;
   title: string;
-  type: NewsType;
+  type: string;
   ago: number;
   thumbImageUrl: string;
 }
@@ -78,4 +75,10 @@ export interface KNewsSearchListCursorPage {
   }[];
   hasNext: boolean;
   nextCursor?: string | null;
+}
+
+// 뉴스 카테고리 타입
+export interface NewsCategory {
+  code: string;
+  name: string;
 }


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-  뉴스 카테고리 노출 방식 변경

## 🔍 작업 상세 내용

- 기존의 프론트엔드 매핑 방식을 제거하고, 서버 데이터를 그대로 UI에 반영하도록 구조를 변경했습니다.
- 불필요해진 `NEWS_CATEGORY_MAPPER` 상수를 삭제하고, 타입 정의를 string으로 일반화했습니다.
- 페이지 진입 시마다 카테고리를 조회하지 않도록 하기 위해 staleTime을 1시간으로 설정했습니다.


## 🏞️ 스크린샷


https://github.com/user-attachments/assets/edc7901e-3631-497a-825d-92cbe78f970c




## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #304 
