### PR TITLE
[hotfix/#308] 안드로이드, iOS 1.3.0 앱 재실행 시 멈춤 문제

### DIFF
--- a/api/axiosInstance.ts
+++ b/api/axiosInstance.ts
@@ -1,10 +1,31 @@
 import { ACCESS_KEY, isRefreshBlocked, REFRESH_KEY } from '@/src/lib/auth/session';
+import { getSecureStoreItem } from '@/src/shared/utils/secureStore';
 import { Config } from '@/src/shared/constants/config';
 import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { router } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
+import { Alert } from 'react-native';
+import { AUTH_ROUTE } from '@/src/shared/constants/route';
 
 const BASE_URL = Config.SERVER_URL;
+
+let hasShownReauthAlert = false;
+let hasNavigatedToAuth = false;
+
+function alertReauth() {
+  if (!hasShownReauthAlert) {
+    hasShownReauthAlert = true;
+    Alert.alert('Session expired', 'Please sign in again.');
+  }
+}
+
+function navigateToAuth() {
+  if (hasNavigatedToAuth) return;
+  hasNavigatedToAuth = true;
+  try {
+    router.replace(AUTH_ROUTE);
+  } catch {}
+}
 
 function shortUrl(base: string, url?: string) {
   if (!url) return '';
@@ -17,13 +38,17 @@ function shortUrl(base: string, url?: string) {
 }
 
 export const doRefresh = async (): Promise<string | null> => {
-  const rt = await SecureStore.getItemAsync(REFRESH_KEY);
+  const rt = await getSecureStoreItem(REFRESH_KEY);
   if (!rt) {
     return null;
   }
 
   try {
     const res = await api.post('/api/v1/member/refresh', { refreshToken: rt });
+
+    if (!res) {
+      return null;
+    }
     const data = (res as any).data?.data || {};
     const newAt: string | undefined = data.accessToken;
     const newRt: string | undefined = data.refreshToken;
@@ -31,6 +56,9 @@ export const doRefresh = async (): Promise<string | null> => {
     if (newAt) {
       await SecureStore.setItemAsync(ACCESS_KEY, newAt);
       (api.defaults.headers as any).Authorization = `Bearer ${newAt}`;
+      // 토큰이 정상 갱신되면 다음 만료 상황에서 다시 Alert를 허용
+      hasShownReauthAlert = false;
+      hasNavigatedToAuth = false;
     }
     if (newRt) {
       await SecureStore.setItemAsync(REFRESH_KEY, newRt);
@@ -56,7 +84,7 @@ api.interceptors.request.use(
       (config.headers as any)['Content-Type'] = 'application/json';
     }
 
-    const token = await SecureStore.getItemAsync(ACCESS_KEY);
+    const token = await getSecureStoreItem(ACCESS_KEY);
     if (token) {
       (config.headers as any).Authorization = `Bearer ${token}`;
     }
@@ -128,7 +156,8 @@ api.interceptors.response.use(
         await SecureStore.deleteItemAsync(ACCESS_KEY);
         await SecureStore.deleteItemAsync(REFRESH_KEY);
 
-        router.replace('/(auth)');
+        alertReauth();
+        navigateToAuth();
 
         return Promise.reject(error);
       }

--- a/src/features/auth/hooks/useAutoLogin.ts
+++ b/src/features/auth/hooks/useAutoLogin.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { doRefresh } from '@/api/axiosInstance';
+import { ACCESS_KEY } from '@/src/lib/auth/session';
+import { fetchUserProfile } from '@/src/shared/api/userProfile';
+import { getSecureStoreItem } from '@/src/shared/utils/secureStore';
 
 export function useAutoLogin(isFontLoaded: boolean) {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
@@ -7,8 +10,38 @@ export function useAutoLogin(isFontLoaded: boolean) {
 
   const autoLogin = useCallback(async () => {
     try {
-      const accessToken = await doRefresh(); // 토큰 갱신 시도
-      setIsLoggedIn(!!accessToken);
+      const [accessToken, storedUserId] = await Promise.all([
+        getSecureStoreItem(ACCESS_KEY),
+        getSecureStoreItem('MyuserId'),
+      ]);
+
+      // 0. userId가 존재하지 않거나 유효하지 않은 경우 로그인 false
+      const userId = storedUserId ? Number(storedUserId) : NaN;
+      if (!Number.isFinite(userId)) {
+        setIsLoggedIn(false);
+        return;
+      }
+
+      // 1.) access token이 있으면 해당 토큰으로 유저 정보 조회로 유효성 검증
+      //    - 200: 로그인 성공
+      //    - 401: axios interceptor가 refresh 후 자동 재시도
+      if (accessToken) {
+        await fetchUserProfile(userId);
+        setIsLoggedIn(true);
+        return;
+      }
+
+      // 2) access token이 없으면 refresh token으로 토큰 갱신 시도
+      const newAccessToken = await doRefresh();
+      if (newAccessToken) {
+        // 토큰 갱신 성공 시 유저 정보 조회로 유효성 검증
+        (await fetchUserProfile(userId), 5000);
+        setIsLoggedIn(true);
+        return;
+      }
+
+      // 3) 모두 실패 시 로그인 false 처리
+      setIsLoggedIn(false);
     } catch (error) {
       console.error('자동 로그인 실패:', error);
       setIsLoggedIn(false);

--- a/src/shared/utils/secureStore.ts
+++ b/src/shared/utils/secureStore.ts
@@ -1,0 +1,25 @@
+import * as SecureStore from 'expo-secure-store';
+
+export async function getSecureStoreItem(key: string): Promise<string | null> {
+  return withFixedTimeout(SecureStore.getItemAsync(key), null);
+}
+
+export async function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timeoutId = setTimeout(() => resolve(fallback), ms);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+const FIXED_TIMEOUT_MS = 2500;
+
+export function withFixedTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  return withTimeout(promise, FIXED_TIMEOUT_MS, fallback);
+}


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

secureStore 접근 시 타임아웃을 추가하고, 자동 로그인 로직을 개선했습니다.

## 🔍 작업 상세 내용

### 1. secureStore 접근 락이 걸렸을 경우를 대비해 타임아웃을 추가했습니다.

앱 초기화 과정에서 secureStore 값 조회가 지연될 경우, 앱 초기화 단계가 끝나지 않아 스플래시 화면이 해제되지 않고 멈출 수 있습니다.
특히 운영 환경에서만 재현되는 케이스는 잠금, 재부팅 직후, OS 정책 등 디바이스 보안 저장소 상태에 영향을 받을 가능성이 있어 무한 대기를 방지하는 방어 로직이 필요합니다.
따라서 secureStore 접근 시 2.5초 타임아웃을 적용해 secureStore의 응답이 지연돼 앱 초기화가 멈추지 않도록 개선했습니다.

### 2. 자동 로그인 로직을 개선했습니다.

⚠️**기존 로직의 문제점**

기존에는 액세스 토큰 체크 및 리프레시 토큰을 이용해 즉시 재발급하는 방식으로 자동 로그인을 진행했습니다.
_(위 자동 로그인 로직은 https://github.com/Kori-AppTeam/Kori_Front_MVP2/pull/10 을 참고 부탁드립니다.)_
이는 불필요한 refresh 호출일 뿐만 아니라, 특정 디바이스/상황에서 secureStore 접근이 지연될 경우 요청이 서버로 가지 못하고 앱이 스플래시 화면에 멈출 수 있습니다. 
따라서 아래와 같은 방식으로 자동 로그인 로직을 개선했습니다.

1️⃣ secure store에서 access token과 userId를 조회
2️⃣ access token이 있으면 해당 토큰으로 user info 조회 API 호출로 토큰이 유효한지 판단
3️⃣ GET `/api/v1/member/{userId}/info` 호출 성공 시 로그인 성공으로 판단하고 홈 화면 진입
4️⃣ 호출이 401로 실패하면 axios interceptor가 refresh를 수행하고 2️⃣번 API 요청을 재시도
5️⃣ refresh 성공 후 재시도 성공 시 로그인 성공 처리
6️⃣ refresh 실패 시에는 secure store의 토큰을 삭제하고, 재로그인 안내 Alert를 1회 노출한 뒤 로그인 화면으로 이동

위 내용들을 모두 적용해도 앱 재실행 시 멈춤 문제가 해결되지 않을 수 있습니다.
PR만 먼저 eas update로 반영해서 테스트하고, 이슈와 브랜치는 닫지 않고 계속 오픈한 상태로 작업 이어가겠습니다.

## 🏞️ 스크린샷

-   X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

X