### PR TITLE
[hotfix#308] 안드로이드, iOS 1.3.0 앱 재실행 시 멈춤 문제

### DIFF
--- a/src/shared/api/getAppVersion.ts
+++ b/src/shared/api/getAppVersion.ts
@@ -1,7 +1,8 @@
-import api from '@/api/axiosInstance';
+import axios from 'axios';
+import { Config } from '@/src/shared/constants/config';
 
 export async function getAppVersion(platform: string, currentVersion: string) {
-  const response = await api.get(`/api/v1/app/version`, {
+  const response = await axios.get(`${Config.SERVER_URL}/api/v1/app/version`, {
     params: { platform, currentVersion },
   });
   return response.data;


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

getAppVersion 호출 시 instance를 기본 axios로 변경했습니다. 

## 🔍 작업 상세 내용

기존에는 getAppVersion 호출 시 공용 api 인스턴스를 사용하고 있었습니다.
해당 인스턴스는 요청 인터셉터에서 SecureStore에 저장된 토큰을 조회해 Authorization 헤더를 주입하는데,
버전 체크 API는 인증이 필요하지 않은 API임에도 불필요하게 SecureStore 접근이 발생했습니다.

운영 환경에서 SecureStore 접근이 콜드스타트 직후 지연/락처럼 동작하는 케이스가 있을 경우, 버전 체크 요청이 실제로 네트워크로 나가기 전에 대기 상태가 길어지면서 스플래시 화면에서 앱이 멈추는 현상이 발생할 수 있다고 판단했습니다.
따라서  기본 axios 를 사용하도록 변경하여, 버전 체크가 로그인 상태와 무관하게 안정적으로 수행되도록 수정했습니다.

위 작업이 운영 환경에 반영되어도 재실행 시 멈춤 문제가 해결되지 않을 수 있습니다.
해결되지 않을 경우, 해당 이슈는 종료 처리하고 Sentry를 도입한 후 새 이슈를 작성해서 작업 이어가겠습니다.

## 🏞️ 스크린샷

-   X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈
