### PR TITLE
[Hotfix/#306] 퀴즈 선택 직후 정답 표시 오류 해결 및 퀴즈/투표 옵션 선택 시 깜빡임 제거

### DIFF
--- a/src/features/community/post/components/PostDetailCard.tsx
+++ b/src/features/community/post/components/PostDetailCard.tsx
@@ -53,12 +53,7 @@ const PostDetailCard = ({ data, onShowProfileModal }: PostDetailCardProps) => {
 
         {/* 퀴즈/투표 컨텐츠 - 텍스트 아래에 */}
         {(parsedMediaInfo.MediaType === 'QUIZ' || parsedMediaInfo.MediaType === 'VOTE') && (
-          <PostPoll
-            type={parsedMediaInfo.MediaType}
-            pollInfo={parsedMediaInfo.pollInfo}
-            pollId={data.id}
-            queryKey={['post', 'detail', data.id]}
-          />
+          <PostPoll type={parsedMediaInfo.MediaType} pollInfo={parsedMediaInfo.pollInfo} pollId={data.id} />
         )}
       </ContentBox>
 

--- a/src/features/community/post/components/PostList.tsx
+++ b/src/features/community/post/components/PostList.tsx
@@ -18,7 +18,7 @@ const PostList = ({ category, sort, scrollRef }: Props) => {
     useGetPosts(CATEGORY_TO_BOARD_ID[category], sort);
 
   const renderPost: ListRenderItem<PostsListItemType> = useCallback(
-    ({ item }) => <PostListCard data={item} boardId={CATEGORY_TO_BOARD_ID[category]} sort={sort} />,
+    ({ item }) => <PostListCard data={item} />,
     [category, sort],
   );
 

--- a/src/features/community/post/components/PostListCard.tsx
+++ b/src/features/community/post/components/PostListCard.tsx
@@ -6,7 +6,7 @@ import { BorderLine, Container, ContentBox, Wrap } from '../../shared/styles/sty
 import { useHandleLikeBookmark } from '../hooks/useHandleLikeBookmark';
 import useVisitor from '../hooks/useVisitor';
 import { useMoreSheetStore } from '../store/useMoreSheetStore';
-import { BoardId, PostsListItemType, SortParam } from '../types';
+import { PostsListItemType } from '../types';
 import { parsePostMediaInfo } from '../utils/postUtils';
 import PostImages from './elements/body/PostImages';
 import PostPoll from './elements/body/PostPoll';
@@ -16,11 +16,9 @@ import PostCommonHeader from './elements/header/PostCommonHeader';
 
 interface PostListCardProps {
   data: PostsListItemType;
-  boardId: BoardId;
-  sort: SortParam;
 }
 
-const PostListCard = ({ data, boardId, sort }: PostListCardProps) => {
+const PostListCard = ({ data }: PostListCardProps) => {
   const SCREEN_WIDTH = Math.round(Dimensions.get('window').width);
 
   const { handleToggleLike, handleToggleBookmark } = useHandleLikeBookmark();
@@ -62,12 +60,7 @@ const PostListCard = ({ data, boardId, sort }: PostListCardProps) => {
 
           {/* 퀴즈/투표 컨텐츠 - 텍스트 아래에 */}
           {(parsedMediaInfo.MediaType === 'QUIZ' || parsedMediaInfo.MediaType === 'VOTE') && (
-            <PostPoll
-              type={parsedMediaInfo.MediaType}
-              pollInfo={parsedMediaInfo.pollInfo}
-              pollId={data.id}
-              queryKey={['post', 'list', boardId, sort]}
-            />
+            <PostPoll type={parsedMediaInfo.MediaType} pollInfo={parsedMediaInfo.pollInfo} pollId={data.id} />
           )}
         </ContentBox>
 

--- a/src/features/community/post/components/elements/body/PostPoll.tsx
+++ b/src/features/community/post/components/elements/body/PostPoll.tsx
@@ -1,7 +1,6 @@
 import QuizBox from '@/src/features/quizAndVote/components/QuizBox';
 import VoteBox from '@/src/features/quizAndVote/components/VoteBox';
 import { PollBaseType } from '@/src/features/quizAndVote/types';
-import { QueryKey } from '@tanstack/react-query';
 import React from 'react';
 import styled from 'styled-components/native';
 
@@ -9,18 +8,17 @@ interface PostPollProps {
   type: 'QUIZ' | 'VOTE';
   pollInfo?: PollBaseType;
   pollId?: number;
-  queryKey?: QueryKey;
 }
 
-const PostPoll = ({ type, pollInfo, pollId, queryKey }: PostPollProps) => {
+const PostPoll = ({ type, pollInfo, pollId }: PostPollProps) => {
   if (!pollId || !pollInfo) {
     return null;
   }
 
   return (
     <PollContainer>
-      {type === 'QUIZ' && <QuizBox pollId={pollId} data={pollInfo} queryKey={queryKey} />}
-      {type === 'VOTE' && <VoteBox pollId={pollId} data={pollInfo} queryKey={queryKey} />}
+      {type === 'QUIZ' && <QuizBox pollId={pollId} data={pollInfo} />}
+      {type === 'VOTE' && <VoteBox pollId={pollId} data={pollInfo} />}
     </PollContainer>
   );
 };

--- a/src/features/community/post/components/elements/body/PostTextContent.tsx
+++ b/src/features/community/post/components/elements/body/PostTextContent.tsx
@@ -17,6 +17,11 @@ type PostTextContentProps = {
 const PostTextContent = ({ isTruncate, content, postId }: PostTextContentProps) => {
   const { handleBlockVisitor } = useVisitor();
 
+  // 내용이 비어있는 경우 렌더링하지 않음(퀴즈/투표에서 텍스트 없는 경우 대비)
+  if (content.trim() === '') {
+    return null;
+  }
+
   const handleMorePress = useCallback(() => {
     if (!postId) return;
     handleBlockVisitor(() => router.push(COMMUNITY_ROUTER.DETAIL(postId)));

--- a/src/features/community/write/hooks/useWriteVote.ts
+++ b/src/features/community/write/hooks/useWriteVote.ts
@@ -9,6 +9,7 @@ export const useWriteVote = () => {
     mutationFn: (body: CreateVotePostBody) => createVotePost(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['post'] });
+      queryClient.invalidateQueries({ queryKey: ['todayPoll', 'VOTE'] });
     },
   });
 };

--- a/src/features/quizAndVote/apis/poll.ts
+++ b/src/features/quizAndVote/apis/poll.ts
@@ -7,7 +7,7 @@ export const getTodayPoll = async (type: 'QUIZ' | 'VOTE') => {
       type: type,
     },
   });
-  return res.data.data;
+  return res.data;
 };
 
 // 퀴즈/투표 참여 결과 전송

--- a/src/features/quizAndVote/components/QuizAndVote.tsx
+++ b/src/features/quizAndVote/components/QuizAndVote.tsx
@@ -48,7 +48,7 @@ const QuizAndVote = () => {
             {tab === 'QUIZ' ? (
               <>
                 <QuizAndVoteHeader title="Today's Quiz" subTitle="Take today's Korean quiz" Character={QuizCharacter} />
-                <QuizBox pollId={data.id} data={data} queryKey={['todayPoll', 'QUIZ']} />
+                <QuizBox pollId={data.id} data={data} />
               </>
             ) : (
               <>
@@ -57,7 +57,7 @@ const QuizAndVote = () => {
                   subTitle="Take Korean favorites poll"
                   Character={VoteCharacter}
                 />
-                <VoteBox pollId={data.id} data={data} queryKey={['todayPoll', 'VOTE']} />
+                <VoteBox pollId={data.id} data={data} />
               </>
             )}
           </>

--- a/src/features/quizAndVote/components/QuizAndVote.tsx
+++ b/src/features/quizAndVote/components/QuizAndVote.tsx
@@ -48,7 +48,7 @@ const QuizAndVote = () => {
             {tab === 'QUIZ' ? (
               <>
                 <QuizAndVoteHeader title="Today's Quiz" subTitle="Take today's Korean quiz" Character={QuizCharacter} />
-                <QuizBox pollId={data.id} data={data} />
+                <QuizBox pollId={data.id} data={data} queryKey={['todayPoll', 'QUIZ']} />
               </>
             ) : (
               <>
@@ -57,7 +57,7 @@ const QuizAndVote = () => {
                   subTitle="Take Korean favorites poll"
                   Character={VoteCharacter}
                 />
-                <VoteBox pollId={data.id} data={data} />
+                <VoteBox pollId={data.id} data={data} queryKey={['todayPoll', 'VOTE']} />
               </>
             )}
           </>

--- a/src/features/quizAndVote/components/QuizBox.tsx
+++ b/src/features/quizAndVote/components/QuizBox.tsx
@@ -17,7 +17,11 @@ const QuizBox = ({ pollId, data, queryKey }: QuizBoxProps) => {
   const { mutate: postPoll } = usePostPoll(queryKey);
   const isExpired = new Date() > new Date(Number(data.closeAt) * 1000);
   const hasSelected = data.selectedOptionId !== null;
-  const showResult = hasSelected || isExpired;
+  // 하이브리드 로직: 참여 직후(isCorrect 사용) + 조회 시(correctOptionId나 선택 상태 사용)
+  const showResult =
+    (hasSelected && data.isCorrect !== null && data.isCorrect !== undefined) || // 참여 직후
+    (hasSelected && data.correctOptionId !== null) || // 조회 시 정답 정보 있음
+    isExpired; // 만료된 경우
 
   const handleSelectOption = (optionId: number) => {
     if (showResult) return; // 결과가 보여지는 상태에서는 선택 불가(퀴즈 참여 한 번만 가능)
@@ -39,13 +43,14 @@ const QuizBox = ({ pollId, data, queryKey }: QuizBoxProps) => {
 
       <OptionRow>
         {data.options.map((option) => {
-          const optionId = option.id ?? option.optionId;
+          const optionId = option.optionId ?? option.id;
 
           return (
             <QuizOption
               key={optionId}
               optionId={optionId}
               content={option.content}
+              isCorrect={data.isCorrect}
               isSelected={data.selectedOptionId === optionId}
               isResult={showResult}
               onPress={() => handleSelectOption(optionId)}

--- a/src/features/quizAndVote/components/QuizBox.tsx
+++ b/src/features/quizAndVote/components/QuizBox.tsx
@@ -1,5 +1,4 @@
 import { formatDate } from '@/src/shared/utils/dateUtils';
-import { QueryKey } from '@tanstack/react-query';
 import React from 'react';
 import { usePostPoll } from '../hooks/usePostPoll';
 import { PollBaseType, TodayPollType } from '../types';
@@ -10,11 +9,10 @@ import QuizOption from './QuizOption';
 interface QuizBoxProps {
   pollId: number;
   data: TodayPollType | PollBaseType;
-  queryKey?: QueryKey;
 }
 
-const QuizBox = ({ pollId, data, queryKey }: QuizBoxProps) => {
-  const { mutate: postPoll } = usePostPoll(queryKey);
+const QuizBox = ({ pollId, data }: QuizBoxProps) => {
+  const { mutate: postPoll } = usePostPoll();
   const isExpired = new Date() > new Date(Number(data.closeAt) * 1000);
   const hasSelected = data.selectedOptionId !== null;
   // 하이브리드 로직: 참여 직후(isCorrect 사용) + 조회 시(correctOptionId나 선택 상태 사용)

--- a/src/features/quizAndVote/components/QuizOption.tsx
+++ b/src/features/quizAndVote/components/QuizOption.tsx
@@ -7,20 +7,50 @@ interface QuizOptionProps {
   optionId: number;
   content: string;
   correctOptionId?: number | null;
+  isCorrect?: boolean;
   isSelected?: boolean;
   isResult?: boolean;
   onPress?: () => void;
 }
 
-const QuizOption = ({ optionId, content, isSelected, isResult, onPress, correctOptionId }: QuizOptionProps) => {
+const QuizOption = ({
+  optionId,
+  content,
+  isCorrect,
+  isSelected,
+  isResult,
+  onPress,
+  correctOptionId,
+}: QuizOptionProps) => {
   const isAnswer = correctOptionId === optionId; // 정답 여부
   const isMyChoice = isSelected; // 내가 선택한 옵션인지 여부
 
+  // 하이브리드 로직: 참여 직후(isCorrect 사용) + 조회 시(isAnswer 사용)
+  const isMyCorrectChoice = isMyChoice && (isCorrect === true || (isCorrect == null && isAnswer));
+  const isMyWrongChoice =
+    isMyChoice && (isCorrect === false || (isCorrect == null && !isAnswer && correctOptionId !== null));
+
   // 옵션 스타일 결정
   const styleProps = () => {
-    // 결과가 보여지는 상태일 때(선택한 값과 정답 비교 - 정답이면 초록색, 오답이면 빨간색, 나머지는 회색)
+    // 결과가 보여지는 상태일 때
     if (isResult) {
-      // 정답인 경우
+      // 내가 정답을 맞춘 경우 - 초록색
+      if (isMyCorrectChoice) {
+        return {
+          backgroundColor: 'transparent',
+          borderColor: theme.colors.primary.mint,
+          textColor: theme.colors.primary.mint,
+        };
+      }
+      // 내가 오답을 선택한 경우 - 빨간색
+      if (isMyWrongChoice) {
+        return {
+          backgroundColor: 'transparent',
+          borderColor: theme.colors.secondary.red,
+          textColor: theme.colors.secondary.red,
+        };
+      }
+      // 정답 옵션 표시 (내가 선택하지 않았지만 정답인 경우) - 초록색
       if (isAnswer) {
         return {
           backgroundColor: 'transparent',
@@ -28,19 +58,20 @@ const QuizOption = ({ optionId, content, isSelected, isResult, onPress, correctO
           textColor: theme.colors.primary.mint,
         };
       }
-      // 오답인 경우(정답 확정 후 오답 처리)
-      if (isMyChoice && !isAnswer && correctOptionId !== null) {
-        return {
-          backgroundColor: 'transparent',
-          borderColor: theme.colors.secondary.red,
-          textColor: theme.colors.secondary.red,
-        };
-      }
       // 내가 선택하지 않은 나머지 옵션들
       return {
         backgroundColor: 'transparent',
         borderColor: theme.colors.gray.darkGray_2,
         textColor: theme.colors.gray.gray_1,
+      };
+    }
+
+    // 내가 선택한 옵션인 경우(결과 공개 전, 낙관적 업데이트 상태)
+    if (isMyChoice) {
+      return {
+        backgroundColor: theme.colors.gray.darkGray_2,
+        borderColor: 'transparent',
+        textColor: theme.colors.primary.white,
       };
     }
 
@@ -56,14 +87,19 @@ const QuizOption = ({ optionId, content, isSelected, isResult, onPress, correctO
   const rightContent = () => {
     // 결과가 보여지는 상태일 때
     if (isResult) {
-      // 정답인 경우
+      // 내가 정답을 맞춘 경우 - 초록 체크
+      if (isMyCorrectChoice) {
+        return <Icon type="check" size={24} color={theme.colors.primary.mint} />;
+      }
+      // 내가 오답을 선택한 경우 - 빨간 X
+      if (isMyWrongChoice) {
+        return <Icon type="close" size={24} color={theme.colors.secondary.red} />;
+      }
+      // 정답 옵션 표시 (내가 선택하지 않았지만 정답인 경우) - 초록 체크
       if (isAnswer) {
         return <Icon type="check" size={24} color={theme.colors.primary.mint} />;
       }
-      // 오답인 경우
-      if (isMyChoice && !isAnswer && correctOptionId !== null) {
-        return <Icon type="close" size={24} color={theme.colors.secondary.red} />;
-      }
+
       // 내가 선택하지 않은 나머지 옵션들
       return null;
     }

--- a/src/features/quizAndVote/components/QuizOption.tsx
+++ b/src/features/quizAndVote/components/QuizOption.tsx
@@ -61,7 +61,7 @@ const QuizOption = ({ optionId, content, isSelected, isResult, onPress, correctO
         return <Icon type="check" size={24} color={theme.colors.primary.mint} />;
       }
       // 오답인 경우
-      if (isMyChoice && !isAnswer) {
+      if (isMyChoice && !isAnswer && correctOptionId !== null) {
         return <Icon type="close" size={24} color={theme.colors.secondary.red} />;
       }
       // 내가 선택하지 않은 나머지 옵션들

--- a/src/features/quizAndVote/components/VoteBox.tsx
+++ b/src/features/quizAndVote/components/VoteBox.tsx
@@ -34,7 +34,7 @@ const VoteBox = ({ pollId, data, queryKey }: VoteBoxProps) => {
 
       <OptionRow>
         {data.options.map((option) => {
-          const optionId = option.id ?? option.optionId;
+          const optionId = option.optionId ?? option.id;
 
           return (
             <VoteOption

--- a/src/features/quizAndVote/components/VoteBox.tsx
+++ b/src/features/quizAndVote/components/VoteBox.tsx
@@ -1,5 +1,4 @@
 import { textStyle, theme } from '@/src/styles/theme';
-import { QueryKey } from '@tanstack/react-query';
 import React from 'react';
 import styled from 'styled-components/native';
 import { usePostPoll } from '../hooks/usePostPoll';
@@ -11,11 +10,10 @@ import VoteOption from './VoteOption';
 interface VoteBoxProps {
   pollId: number;
   data: TodayPollType | PollBaseType;
-  queryKey?: QueryKey;
 }
 
-const VoteBox = ({ pollId, data, queryKey }: VoteBoxProps) => {
-  const { mutate: postPoll } = usePostPoll(queryKey);
+const VoteBox = ({ pollId, data }: VoteBoxProps) => {
+  const { mutate: postPoll } = usePostPoll();
   const showResult = data.selectedOptionId !== null;
 
   const handleSelectOption = (optionId: number) => {

--- a/src/features/quizAndVote/hooks/useGetTodayPoll.ts
+++ b/src/features/quizAndVote/hooks/useGetTodayPoll.ts
@@ -5,7 +5,10 @@ import { TodayPollType } from '../types';
 export const useGetTodayPoll = (type: 'QUIZ' | 'VOTE') => {
   return useQuery<TodayPollType>({
     queryKey: ['todayPoll', type],
-    queryFn: () => getTodayPoll(type),
+    queryFn: async () => {
+      const response = await getTodayPoll(type);
+      return response.data; // data 부분만 반환
+    },
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
 };

--- a/src/features/quizAndVote/hooks/usePostPoll.ts
+++ b/src/features/quizAndVote/hooks/usePostPoll.ts
@@ -3,31 +3,34 @@ import { postPoll } from '../apis/poll';
 import { OptionType, PollBaseType, PostPollParams, QuizAndVoteResponse } from '../types';
 
 interface Context {
-  previousData?: any;
-  queryKey?: QueryKey;
+  postListData?: Array<[QueryKey, unknown]>;
+  postDetailData?: unknown;
+  todayPollData?: unknown;
 }
 
-export const usePostPoll = (targetQueryKey?: QueryKey) => {
+export const usePostPoll = () => {
   const queryClient = useQueryClient();
 
   return useMutation<QuizAndVoteResponse, unknown, PostPollParams, Context>({
     mutationFn: ({ pollId, optionId }) => postPoll(pollId, optionId),
-
     // 낙관적 업데이트 (선택 즉시 선택값 먼저 반영 - 깜빡임 최소화)
     onMutate: async (variables) => {
-      const queryKey = targetQueryKey || ['todayPoll', variables.pollType];
+      await queryClient.cancelQueries({ queryKey: ['post', 'list'] });
+      await queryClient.cancelQueries({ queryKey: ['post', 'detail', variables.pollId] });
+      await queryClient.cancelQueries({ queryKey: ['todayPoll', variables.pollType] });
 
-      await queryClient.cancelQueries({ queryKey });
-      const previousData = queryClient.getQueryData(queryKey);
+      const postListData = queryClient.getQueriesData({ queryKey: ['post', 'list'] });
+      const postDetailData = queryClient.getQueryData(['post', 'detail', variables.pollId]);
+      const todayPollData = queryClient.getQueryData(['todayPoll', variables.pollType]);
 
-      queryClient.setQueryData(queryKey, (old: any) => {
-        if (!old) return old;
+      // update 로직 (선택값 변경)
+      const updateFn = (originalData: PollBaseType) => ({
+        ...originalData,
+        selectedOptionId: variables.optionId,
+      });
 
-        // update 로직 (선택값 변경)
-        const updateFn = (originalData: PollBaseType) => ({
-          ...originalData,
-          selectedOptionId: variables.optionId,
-        });
+      queryClient.setQueriesData({ queryKey: ['post', 'list'] }, (old: any) => {
+        if (!old?.pages) return old;
 
         // 1. 리스트 (무한스크롤)
         if (old.pages && Array.isArray(old.pages)) {
@@ -47,51 +50,55 @@ export const usePostPoll = (targetQueryKey?: QueryKey) => {
             })),
           };
         }
-
-        // 2. 단일 객체 (상세/투표)
-        if (old.pollInfo) {
-          // PostPollDetail 구조: { ...postDetail, pollInfo: PollBaseType }
-          return {
-            ...old,
-            pollInfo: updateFn(old.pollInfo),
-          };
-        } else {
-          // TodayPoll 구조: TodayPollType (직접)
-          return updateFn(old);
-        }
+        return old;
       });
 
-      return { previousData, queryKey };
-    },
+      // 2. 단일 객체 (상세)
+      queryClient.setQueryData(['post', 'detail', variables.pollId], (old: any) => {
+        if (!old?.pollInfo) return old;
 
+        return {
+          ...old,
+          pollInfo: updateFn(old.pollInfo),
+        };
+      });
+
+      // 3. TodayPoll
+      queryClient.setQueryData(['todayPoll', variables.pollType], (old: any) => {
+        if (!old) return old;
+        return updateFn(old);
+      });
+
+      return { postListData, postDetailData, todayPollData };
+    },
     // 서버 응답 후 데이터 동기화 (결과값 반영)
     onSuccess: (serverResponse, variables) => {
-      const queryKey = targetQueryKey || ['todayPoll', variables.pollType];
       const { results, correctOptionId, isCorrect } = serverResponse.data;
 
       if (!results) return;
 
-      queryClient.setQueryData(queryKey, (old: any) => {
-        if (!old) return old;
+      // update 로직 (투표 결과 반영)
+      const updateFn = (originalData: PollBaseType) => {
+        const updatedOptions = originalData.options.map((option: OptionType) => {
+          const optionId = option.optionId ?? option.id;
+          const serverResult = results.find((r) => r.optionId === optionId);
+          return serverResult ? { ...option, voteCount: serverResult.voteCount } : option;
+        });
 
-        // update 로직 (투표 결과 반영)
-        const updateFn = (originalData: PollBaseType) => {
-          const updatedOptions = originalData.options.map((option: OptionType) => {
-            const optionId = option.optionId ?? option.id;
-            const serverResult = results.find((r) => r.optionId === optionId);
-            return serverResult ? { ...option, voteCount: serverResult.voteCount } : option;
-          });
+        const newTotalVoteCount = updatedOptions.reduce((acc, cur) => acc + cur.voteCount, 0);
 
-          const newTotalVoteCount = updatedOptions.reduce((acc, cur) => acc + cur.voteCount, 0);
-
-          return {
-            ...originalData,
-            correctOptionId: correctOptionId ?? originalData.correctOptionId,
-            totalVoteCount: newTotalVoteCount,
-            options: updatedOptions,
-            isCorrect: isCorrect ?? false,
-          };
+        return {
+          ...originalData,
+          correctOptionId: correctOptionId ?? originalData.correctOptionId,
+          totalVoteCount: newTotalVoteCount,
+          options: updatedOptions,
+          // 퀴즈인 경우에만 isCorrect 설정
+          ...(correctOptionId !== undefined && { isCorrect: isCorrect ?? false }),
         };
+      };
+
+      queryClient.setQueriesData({ queryKey: ['post', 'list'] }, (old: any) => {
+        if (!old?.pages) return old;
 
         // 1. 리스트 (무한스크롤)
         if (old.pages && Array.isArray(old.pages)) {
@@ -111,29 +118,36 @@ export const usePostPoll = (targetQueryKey?: QueryKey) => {
             })),
           };
         }
-
-        // 2. 단일 객체 (상세/투표)
-        if (old.pollInfo) {
-          // PostPollDetail 구조
-          return {
-            ...old,
-            pollInfo: updateFn(old.pollInfo),
-          };
-        } else {
-          // TodayPoll 구조: TodayPollType (직접)
-          return updateFn(old);
-        }
+        return old;
       });
 
-      // 3. 모든 관련 캐시 무효화 (페이지 이동 후에도 최신 데이터 보장)
-      queryClient.invalidateQueries({ queryKey: ['post', 'list'] });
-      queryClient.invalidateQueries({ queryKey: ['todayPoll', variables.pollType] });
-      queryClient.invalidateQueries({ queryKey: ['post', 'detail', variables.pollId] });
-    },
+      // 2. 단일 객체 (상세)
+      queryClient.setQueryData(['post', 'detail', variables.pollId], (old: any) => {
+        if (!old?.pollInfo) return old;
 
+        return {
+          ...old,
+          pollInfo: updateFn(old.pollInfo),
+        };
+      });
+
+      // 3. TodayPoll
+      queryClient.setQueryData(['todayPoll', variables.pollType], (old: any) => {
+        if (!old) return old;
+        return updateFn(old);
+      });
+    },
     onError: (err, variables, context) => {
-      if (context?.previousData && context?.queryKey) {
-        queryClient.setQueryData(context.queryKey, context.previousData);
+      if (context?.postListData) {
+        context.postListData.forEach(([queryKey, data]) => {
+          queryClient.setQueryData(queryKey, data);
+        });
+      }
+      if (context?.postDetailData) {
+        queryClient.setQueryData(['post', 'detail', variables.pollId], context.postDetailData);
+      }
+      if (context?.todayPollData) {
+        queryClient.setQueryData(['todayPoll', variables.pollType], context.todayPollData);
       }
     },
   });

--- a/src/features/quizAndVote/hooks/usePostPoll.ts
+++ b/src/features/quizAndVote/hooks/usePostPoll.ts
@@ -55,7 +55,7 @@ export const usePostPoll = () => {
 
       // 2. 단일 객체 (상세)
       queryClient.setQueryData(['post', 'detail', variables.pollId], (old: any) => {
-        if (!old?.pollInfo) return old;
+        if (!old?.pollInfo || old.id !== variables.pollId) return old;
 
         return {
           ...old,
@@ -65,7 +65,7 @@ export const usePostPoll = () => {
 
       // 3. TodayPoll
       queryClient.setQueryData(['todayPoll', variables.pollType], (old: any) => {
-        if (!old) return old;
+        if (!old || old.id !== variables.pollId) return old;
         return updateFn(old);
       });
 
@@ -123,7 +123,7 @@ export const usePostPoll = () => {
 
       // 2. 단일 객체 (상세)
       queryClient.setQueryData(['post', 'detail', variables.pollId], (old: any) => {
-        if (!old?.pollInfo) return old;
+        if (!old?.pollInfo || old.id !== variables.pollId) return old;
 
         return {
           ...old,
@@ -133,7 +133,7 @@ export const usePostPoll = () => {
 
       // 3. TodayPoll
       queryClient.setQueryData(['todayPoll', variables.pollType], (old: any) => {
-        if (!old) return old;
+        if (!old || old.id !== variables.pollId) return old;
         return updateFn(old);
       });
     },

--- a/src/features/quizAndVote/hooks/usePostPoll.ts
+++ b/src/features/quizAndVote/hooks/usePostPoll.ts
@@ -2,11 +2,69 @@ import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
 import { postPoll } from '../apis/poll';
 import { OptionType, PollBaseType, PostPollParams, QuizAndVoteResponse } from '../types';
 
+interface Context {
+  previousData?: any;
+  queryKey?: QueryKey;
+}
+
 export const usePostPoll = (targetQueryKey?: QueryKey) => {
   const queryClient = useQueryClient();
 
-  return useMutation<QuizAndVoteResponse, unknown, PostPollParams>({
+  return useMutation<QuizAndVoteResponse, unknown, PostPollParams, Context>({
     mutationFn: ({ pollId, optionId }) => postPoll(pollId, optionId),
+
+    // 낙관적 업데이트 (선택 즉시 선택값 먼저 반영 - 깜빡임 최소화)
+    onMutate: async (variables) => {
+      const queryKey = targetQueryKey || ['todayPoll', variables.pollType];
+
+      await queryClient.cancelQueries({ queryKey });
+      const previousData = queryClient.getQueryData(queryKey);
+
+      queryClient.setQueryData(queryKey, (old: any) => {
+        if (!old) return old;
+
+        // update 로직 (선택값 변경)
+        const updateFn = (originalData: PollBaseType) => ({
+          ...originalData,
+          selectedOptionId: variables.optionId,
+        });
+
+        // 1. 리스트 (무한스크롤)
+        if (old.pages && Array.isArray(old.pages)) {
+          return {
+            ...old,
+            pages: old.pages.map((page: any) => ({
+              ...page,
+              data: {
+                ...page.data,
+                items: page.data.items.map((item: any) => {
+                  if (item.id === variables.pollId && item.pollInfo) {
+                    return { ...item, pollInfo: updateFn(item.pollInfo) };
+                  }
+                  return item;
+                }),
+              },
+            })),
+          };
+        }
+
+        // 2. 단일 객체 (상세/투표)
+        if (old.pollInfo) {
+          // PostPollDetail 구조: { ...postDetail, pollInfo: PollBaseType }
+          return {
+            ...old,
+            pollInfo: updateFn(old.pollInfo),
+          };
+        } else {
+          // TodayPoll 구조: TodayPollType (직접)
+          return updateFn(old);
+        }
+      });
+
+      return { previousData, queryKey };
+    },
+
+    // 서버 응답 후 데이터 동기화 (결과값 반영)
     onSuccess: (serverResponse, variables) => {
       const queryKey = targetQueryKey || ['todayPoll', variables.pollType];
       const { results, correctOptionId, isCorrect } = serverResponse.data;
@@ -16,30 +74,26 @@ export const usePostPoll = (targetQueryKey?: QueryKey) => {
       queryClient.setQueryData(queryKey, (old: any) => {
         if (!old) return old;
 
-        const updatePollData = (originalData: PollBaseType) => {
+        // update 로직 (투표 결과 반영)
+        const updateFn = (originalData: PollBaseType) => {
           const updatedOptions = originalData.options.map((option: OptionType) => {
-            const optionId = option.id ?? option.optionId;
+            const optionId = option.optionId ?? option.id;
             const serverResult = results.find((r) => r.optionId === optionId);
             return serverResult ? { ...option, voteCount: serverResult.voteCount } : option;
           });
 
-          // totalVoteCount 재계산
-          const newTotalVoteCount = updatedOptions.reduce(
-            (sum: number, option: OptionType) => sum + option.voteCount,
-            0,
-          );
+          const newTotalVoteCount = updatedOptions.reduce((acc, cur) => acc + cur.voteCount, 0);
 
           return {
             ...originalData,
             correctOptionId: correctOptionId ?? originalData.correctOptionId,
-            selectedOptionId: variables.optionId,
             totalVoteCount: newTotalVoteCount,
             options: updatedOptions,
             isCorrect: isCorrect ?? false,
           };
         };
 
-        // 무한스크롤 구조인지 확인 (게시글 리스트)
+        // 1. 리스트 (무한스크롤)
         if (old.pages && Array.isArray(old.pages)) {
           return {
             ...old,
@@ -48,12 +102,8 @@ export const usePostPoll = (targetQueryKey?: QueryKey) => {
               data: {
                 ...page.data,
                 items: page.data.items.map((item: any) => {
-                  // 해당 pollId를 가진 아이템 찾아서 업데이트
                   if (item.id === variables.pollId && item.pollInfo) {
-                    return {
-                      ...item,
-                      pollInfo: updatePollData(item.pollInfo),
-                    };
+                    return { ...item, pollInfo: updateFn(item.pollInfo) };
                   }
                   return item;
                 }),
@@ -62,36 +112,29 @@ export const usePostPoll = (targetQueryKey?: QueryKey) => {
           };
         }
 
-        // 단순 구조 (상세 페이지, k-culture 탭)
-        const isPostType = !!old.pollInfo;
-        const targetData = isPostType ? old.pollInfo : old;
-
-        const updatedTarget = updatePollData(targetData);
-
-        if (isPostType) {
+        // 2. 단일 객체 (상세/투표)
+        if (old.pollInfo) {
+          // PostPollDetail 구조
           return {
             ...old,
-            pollInfo: updatedTarget,
+            pollInfo: updateFn(old.pollInfo),
           };
+        } else {
+          // TodayPoll 구조: TodayPollType (직접)
+          return updateFn(old);
         }
-
-        return updatedTarget;
       });
 
-      // 1. 상세 페이지 데이터 무효화
-      queryClient.invalidateQueries({
-        queryKey: ['post', 'detail', variables.pollId],
-      });
+      // 3. 모든 관련 캐시 무효화 (페이지 이동 후에도 최신 데이터 보장)
+      queryClient.invalidateQueries({ queryKey: ['post', 'list'] });
+      queryClient.invalidateQueries({ queryKey: ['todayPoll', variables.pollType] });
+      queryClient.invalidateQueries({ queryKey: ['post', 'detail', variables.pollId] });
+    },
 
-      // 2. 리스트 데이터 무효화 (전체 게시글 목록)
-      queryClient.invalidateQueries({
-        queryKey: ['post', 'list'],
-      });
-
-      // 3. k-culture 탭 투표 데이터 무효화
-      queryClient.invalidateQueries({
-        queryKey: ['todayPoll', variables.pollType],
-      });
+    onError: (err, variables, context) => {
+      if (context?.previousData && context?.queryKey) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
     },
   });
 };

--- a/src/features/quizAndVote/hooks/usePostPoll.ts
+++ b/src/features/quizAndVote/hooks/usePostPoll.ts
@@ -90,7 +90,7 @@ export const usePostPoll = (targetQueryKey?: QueryKey) => {
 
       // 3. k-culture 탭 투표 데이터 무효화
       queryClient.invalidateQueries({
-        queryKey: ['todayPoll', 'VOTE'],
+        queryKey: ['todayPoll', variables.pollType],
       });
     },
   });

--- a/src/features/quizAndVote/types/index.ts
+++ b/src/features/quizAndVote/types/index.ts
@@ -7,6 +7,7 @@ export interface PollBaseType {
   options: OptionType[];
   selectedOptionId: number | null; // 사용자가 선택한 옵션 ID, 선택하지 않았으면 null
   correctOptionId?: number | null; // 퀴즈인 경우 정답 옵션 ID
+  isCorrect?: boolean; // 퀴즈인 경우 사용자가 맞췄는지 여부(참여 직후에만 존재)
 }
 
 // 퀴즈, 투표

--- a/src/features/quizAndVote/types/index.ts
+++ b/src/features/quizAndVote/types/index.ts
@@ -15,6 +15,13 @@ export interface TodayPollType extends PollBaseType {
   type: 'QUIZ' | 'VOTE';
 }
 
+// 오늘의 퀴즈/투표 서버 응답 타입
+export interface TodayPollServerResp {
+  message: string;
+  data: TodayPollType;
+  timestamp: string;
+}
+
 export interface OptionType {
   id: number;
   optionId?: number;


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-  퀴즈 정답 표시 로직 수정
- 퀴즈, 투표 옵션 선택 시 깜빡임 제거

## 🔍 작업 상세 내용

### 1️⃣ 퀴즈 정답 표시 로직 수정
`문제` 
- 기존 로직의 경우 값을 선택한 상태(`selectedOptionId`), 그리고 만료일에 따라 결과 표시 여부(`showResult`)를 결정하고 있었고, `showResult`가 참이면 `correctOptionId`를 QuizOption 컴포넌트에 넘겨주고 있었습니다. 
- 퀴즈는 값을 선택한 경우(`selectedOptionId`이 존재할 때), 그리고 마감일이 지난 경우 서버에서 `correctOptionId` 값을 넘겨주기로 되어 있었기 때문에 `correctOptionId`값으로 정답을 체크하는 로직을 짰습니다.
-  하지만 퀴즈 참여 직후(`usePostPoll`)에는 선택한 답이 정답일 경우 `correctOptionId`값이 `null`로 오고, 정답이 아닐 경우에만 `correctOptionId` 값이 넘어와서 QuizBox 컴포넌트에서 `correctOptionId`값을 QuizOption 컴포넌트로 제대로 넘겨주지 못했습니다. 이로 인해 퀴즈 참여 직후에는 결과 화면이 바로 업데이트되지 않고, refetch를 해야만 결과를 확인할 수 있었습니다. 

`해결` 
- 기존 로직이 퀴즈 참여 직후 정답이든 오답이든 `correctOptionId` 값이 무조건 넘어온다는 것을 가정하고 짜여졌기에 오류가 발생했던 것이라서, 참여 직후에는 별도로 isCorrect 값으로 결과를 확인할 수 있도록 수정이 필요했습니다.
- 참여 직후 결과를 바로 보여줄 수 있도록 correctOptionId와 isCorrect 값을 모두 검사하도록 로직을 수정했습니다.
    - **단순 조회 시**: isCorrect값이 아닌 corretOptionId로 퀴즈 정답을 확인
    - **참여 직후**: isCorrect값으로 정답 여부 판별

### 2️⃣ 퀴즈/투표 참여 직후 깜빡임 제거 및 낙관적 업데이트 적용
- 기존에는 onMutate를 사용하지 않고(낙관적 업데이트 없이) invalidateQueries로 쿼리키를 무효화했기 때문에 데이터를 새로 받아오느라 깜빡임이 발생했습니다.
- 따라서 usePostPoll 로직을 수정하여 낙관적 업데이트로는 selectedOptionId를 먼저 업데이트하고, 이후 서버 응답을 받아서 퀴즈 및 투표 결과를 보여주도록 수정했습니다.
- 추가로 퀴즈/투표의 경우 모든 관련 데이터를 바로바로 동기화시켜야 한다고 판단하여 훅에서 받던 targetQueryKey prop을 제거하고 훅 내부에서 자체적으로 처리할 수 있도록 재수정하였습니다.  

### 3️⃣ PostTextContent 컴포넌트에서 content가 비어있는 경우 렌더링하지 않도록 처리
투표 게시글은 글 본문 없이 글 작성이 가능한데, 그럴 경우 아래와 같이 content 부분에 빈 공간이 노출되어 PostTextContent 컴포넌트에 관련 로직을 추가하였습니다. 
<img width="200" alt="스크린샷 2026-02-10 오전 3 23 16" src="https://github.com/user-attachments/assets/ae91a87d-6178-4887-be64-edd85634780f" />

### 4️⃣ 투표 게시글 작성 시 오늘의 poll 데이터 무효화
- K-Culture 탭의 'Quiz&Vote(todayPoll)' 영역은 커뮤니티 탭의 가장 최신 게시글을 노출하도록 되어 있습니다.
- useGetTodayPoll의 staleTime(5분) 때문에, 투표 글을 새로 작성하더라도 K-Culture 탭에는 여전히 이전 게시글이 노출되는 현상이 있었습니다. (새 글이 아닌 구형 데이터가 남아있어 최신 투표 현황 확인 불가 및 구형 데이터에서도 내가 선택한 값 확인 불가)
- 따라서 useWriteVote 훅에서 글 작성 성공 시 todayPoll 투표 쿼리를 즉시 무효화(invalidate)하여, 작성한 새 글이 K-Culture 탭에도 바로 반영되도록 수정했습니다.

### ⚠️ 테스트 가이드
#### 1. 테스트 전
- 퀴즈 작성은 `/api/v2/poll/quiz` api를 사용하여 postman으로 진행해야 합니다(content 필수).
- 퀴즈의 경우 useGetTodayPoll 훅의 staleTime을 주석처리하고 community 탭, k-culture 탭에서 퀴즈와 투표 데이터 동기화가 바로바로 되는지 테스트 부탁드립니다. 
- 투표는 staleTime을 다시 5분으로 설정하고 테스트 부탁드립니다. 
#### 2. 퀴즈 기능 테스트
- 참여 직후에 k-culture, community 탭에서 결과가 바로 나타나는지 확인 부탁드립니다. 
#### 3. 4️⃣ 투표 테스트
- **staleTime 다시 5분으로 설정**
1. k-culture 탭에 노출되어 있는 투표 참여
2. community 탭으로 이동해 새로운 투표 글 작성
3. 방금 생성된 투표에 바로 참여
4. k-culture 탭으로 이동하여 vote탭에 방금 생성한 글과 내가 투표한 옵션이 잘 보이는지(초록색으로 표시되는지) 확인

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #306 
