### PR TITLE
[hotfix/#307] 안드로이드 1.3.0 구글 oauth 불가능 & 앱 먹통 문제

### DIFF
--- a/src/features/auth/components/SignInButtonWrapper.tsx
+++ b/src/features/auth/components/SignInButtonWrapper.tsx
@@ -46,13 +46,13 @@ function SignInButtonWrapper({ onSuccessSocialSignIn }: SignInButtonWrapperProps
       }
     } catch (error) {
       const errorCode = getAuthErrorCode(error, 'apple');
-      const errorConfig = APPLE_AUTH_ERROR[errorCode];
+      const errorConfig = APPLE_AUTH_ERROR[errorCode] ?? APPLE_AUTH_ERROR.UNKNOWN_ERROR;
 
       // 사용자가 로그인을 취소한 경우를 제외하고 error toast 표시
-      if (errorConfig !== APPLE_AUTH_ERROR.ERR_REQUEST_CANCELED) {
+      if (errorCode !== 'ERR_REQUEST_CANCELED') {
         Toast.show({
           type: 'error',
-          text1: errorConfig.message,
+          text1: errorConfig?.message ?? APPLE_AUTH_ERROR.UNKNOWN_ERROR.message,
           text2: errorConfig.subMessage || 'Please try again later.',
         });
       }
@@ -74,16 +74,13 @@ function SignInButtonWrapper({ onSuccessSocialSignIn }: SignInButtonWrapperProps
       }
     } catch (error) {
       const errorCode = getAuthErrorCode(error, 'google');
-      const errorConfig = GOOGLE_AUTH_ERROR[errorCode];
+      const errorConfig = GOOGLE_AUTH_ERROR[errorCode] ?? GOOGLE_AUTH_ERROR.UNKNOWN_ERROR;
 
       // 사용자가 로그인을 취소하거나 이미 로그인 진행중인 경우를 제외하고 error toast 표시
-      if (
-        errorConfig !== GOOGLE_AUTH_ERROR[statusCodes.SIGN_IN_CANCELLED] &&
-        errorConfig !== GOOGLE_AUTH_ERROR[statusCodes.IN_PROGRESS]
-      ) {
+      if (errorCode !== statusCodes.SIGN_IN_CANCELLED && errorCode !== statusCodes.IN_PROGRESS) {
         Toast.show({
           type: 'error',
-          text1: errorConfig.message,
+          text1: errorConfig?.message ?? GOOGLE_AUTH_ERROR.UNKNOWN_ERROR.message,
           text2: 'Please try again later.',
         });
       }

--- a/src/shared/utils/getAxiosErrorCode.ts
+++ b/src/shared/utils/getAxiosErrorCode.ts
@@ -14,7 +14,8 @@ import axios from 'axios';
 
 export function getAxiosErrorCode(error: unknown): string {
   if (axios.isAxiosError(error)) {
-    return error.response?.data?.error_code;
+    const code = (error.response?.data as any)?.error_code;
+    return code ? String(code) : 'UNKNOWN_ERROR';
   }
   return 'UNKNOWN_ERROR';
 }

--- a/src/shared/utils/showUpdateAlert.ts
+++ b/src/shared/utils/showUpdateAlert.ts
@@ -25,7 +25,7 @@ export function showUpdateErrorAlert(error: unknown) {
   const errorConfig = getAxiosErrorCode(error);
 
   const title = 'Version Error';
-  const message = APP_VERSION_CHECK_ERROR[errorConfig].message || APP_VERSION_CHECK_ERROR['UNKNOWN_STATUS'].message;
+  const message = APP_VERSION_CHECK_ERROR[errorConfig]?.message ?? APP_VERSION_CHECK_ERROR.UNKNOWN_STATUS.message;
   Alert.alert(title, message, [
     {
       text: 'OK',


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

앱 초기화 및 oauth 로그인 시 불분명한 에러가 발생할 경우, fallback 에러코드를 통해 `unknown error`로 처리되도록 개선했습니다.

## 🔍 작업 상세 내용

<img width="1034" height="386" alt="스크린샷 2026-02-17 오전 2 53 56" src="https://github.com/user-attachments/assets/2c6bdc37-d1a1-4ae9-8cc9-fbf6a394062f" />

> Sentry 로그 확인 결과, 구글 로그인 시도 시 `TypeError: Cannot read property 'message' of undefined` 에러가 발생하는 것으로 추정됩니다.


### 추정 원인

SDK/서버에서 내려주는 에러 코드가 프론트의 에러 매핑에 정의되지 않은 값인 경우일 것으로 예상됩니다.
위 경우, 에러 코드에 대한 에러 메시지 매핑 결과인 `errorConfig`가 `undefined`가 되어, `errorConfig.message` 실행 시 `TypeError: Cannot read property 'message' of undefined` 에러가 발생할 수 있습니다.

### 개선 사항

1. `googleSignIn`, `appleSignIn` 에러 처리에서 매핑되지 않은 에러 코드가 들어와도 `UNKNOWN_ERROR`로 fallback 되도록 처리했습니다.
2. `getAxiosErrorCode` 유틸에서 `error_code`가 없을 수 있는 케이스를 고려해 항상 문자열을 반환하고, 없으면 `UNKNOWN_ERROR`로 fallback 하도록 처리했습니다.
2. 앱 버전 확인 중 에러가 발생했을 때 실행되는 `showUpdateErrorAlert`에서, 매핑되지 않은 코드로 인해 `.message` 접근이 실패하지 않도록 fallback 처리를 추가했습니다.


OTA로 업데이트한 후 운영 환경에서 테스트가 필요합니다.
테스트 후에도 해당 문제가 해결되지 않으면 Sentry 로깅 코드를 추가할 예정입니다.

## 🏞️ 스크린샷

-   X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #307 