### PR TITLE
[chore/#307] sentry 에러 캡처 및 breadcrumb 추가

### DIFF
--- a/src/shared/hooks/useCheckAppVersion.ts
+++ b/src/shared/hooks/useCheckAppVersion.ts
@@ -3,7 +3,7 @@ import Constants from 'expo-constants';
 import { useCallback, useEffect, useState } from 'react';
 import { getAppVersion } from '@/src/shared/api/getAppVersion';
 import { showUpdateAlert, showUpdateErrorAlert } from '@/src/shared/utils/showUpdateAlert';
-import { current } from 'immer';
+import { captureErrorWithContext, addSentryBreadcrumb } from '@/src/shared/utils/sentry';
 
 export function useCheckAppVersion() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -14,11 +14,37 @@ export function useCheckAppVersion() {
 
   // 앱 버전 확인 및 업데이트 Alert 표시
   const checkAppVersion = useCallback(async () => {
+    // 버전 체크 시작 breadcrumb
+    addSentryBreadcrumb({
+      category: 'version_check',
+      message: 'Starting app version check',
+      data: {
+        currentVersion,
+        platform,
+      },
+    });
+
     try {
       if (!currentVersion) {
         throw new Error('APP_VERSION_NOT_FOUND'); // 앱 버전 정보를 찾을 수 없는 경우 error 처리
       }
+
+      // API 호출 전 breadcrumb
+      addSentryBreadcrumb({
+        category: 'version_check',
+        message: 'Calling getAppVersion API',
+        data: { platform, currentVersion },
+      });
+
       const { status, title, message, storeUrl } = await getAppVersion(platform, currentVersion);
+
+      // API 응답 breadcrumb
+      addSentryBreadcrumb({
+        category: 'version_check',
+        message: 'getAppVersion API response received',
+        data: { status, title, hasStoreUrl: !!storeUrl },
+      });
+
       switch (status) {
         // 강제 업데이트 Alert
         case 'FORCE_UPDATE':
@@ -41,6 +67,18 @@ export function useCheckAppVersion() {
           throw new Error('UNKNOWN_STATUS'); // 알 수 없는 status인 경우 error 처리
       }
     } catch (error: unknown) {
+      // Sentry에 에러 캡처
+      captureErrorWithContext(error, {
+        location: 'useCheckAppVersion',
+        additionalData: {
+          currentVersion,
+          platform,
+        },
+        tags: {
+          platform,
+        },
+      });
+
       showUpdateErrorAlert(error); // 에러 Alert 표시
     } finally {
       setIsLoading(false);

--- a/src/shared/utils/sentry.ts
+++ b/src/shared/utils/sentry.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react-native';
+import axios from 'axios';
 
 let isSentryInitialized = false;
 
@@ -41,4 +42,84 @@ export function wrapWithSentry<TProps extends Record<string, unknown>>(
   Component: ComponentType<TProps>,
 ): ComponentType<TProps> {
   return Sentry.wrap(Component as ComponentType<Record<string, unknown>>) as ComponentType<TProps>;
+}
+
+/**
+ * 에러를 컨텍스트와 함께 Sentry에 캡처합니다.
+ * Axios 에러, 일반 Error, 기타 에러 타입을 자동으로 감지하여 상세 정보를 추출합니다.
+ *
+ * @param error - 캡처할 에러 객체
+ * @param context - 에러 발생 위치 및 추가 컨텍스트 정보
+ */
+export function captureErrorWithContext(
+  error: unknown,
+  context: {
+    location: string;
+    additionalData?: Record<string, any>;
+    tags?: Record<string, string>;
+    level?: Sentry.SeverityLevel;
+  },
+) {
+  const { location, additionalData = {}, tags = {}, level = 'error' } = context;
+
+  // 에러 상세 정보 추출
+  const errorInfo: Record<string, any> = {
+    ...additionalData,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Axios 에러인 경우
+  if (axios.isAxiosError(error)) {
+    errorInfo.type = 'AxiosError';
+    errorInfo.status = error.response?.status;
+    errorInfo.statusText = error.response?.statusText;
+    errorInfo.responseData = error.response?.data;
+    errorInfo.requestUrl = error.config?.url;
+    errorInfo.requestMethod = error.config?.method;
+    errorInfo.message = error.message;
+    errorInfo.code = error.code;
+  }
+  // 일반 Error 객체인 경우
+  else if (error instanceof Error) {
+    errorInfo.type = 'Error';
+    errorInfo.name = error.name;
+    errorInfo.message = error.message;
+    errorInfo.stack = error.stack;
+  }
+  // 기타 에러
+  else {
+    errorInfo.type = 'Unknown';
+    errorInfo.rawError = String(error);
+  }
+
+  // Sentry에 상세 정보와 함께 캡처
+  Sentry.captureException(error, {
+    tags: {
+      error_location: location,
+      ...tags,
+    },
+    contexts: {
+      error_details: errorInfo,
+    },
+    level,
+  });
+}
+
+/**
+ * Sentry breadcrumb를 추가합니다.
+ *
+ * @param breadcrumb - breadcrumb 정보
+ */
+export function addSentryBreadcrumb(breadcrumb: {
+  category: string;
+  message: string;
+  level?: Sentry.SeverityLevel;
+  data?: Record<string, any>;
+}) {
+  Sentry.addBreadcrumb({
+    category: breadcrumb.category,
+    message: breadcrumb.message,
+    level: breadcrumb.level || 'info',
+    data: breadcrumb.data,
+  });
 }


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   Sentry 에러 캡처 및 breadcrumb를 추가했습니다.

## 🔍 작업 상세 내용

이전 PR(#323)에서 OTA로 fallback error를 반영한 결과, 운영 환경에서 앱 초기화 시 스플래시 스크린에서 fallback error 관련 Alert가 노출되었습니다.
이에 따라, 에러를 더욱 자세히 로깅하기 위한 Sentry 에러 캡처 및 breadcrumb 유틸 함수를 추가하고, useCheckAppVersion 훅에서 로직 및 API 수행 전/후로 에러 캡쳐 및 breadcrumb를 호출하도록 수정했습니다.


## 🏞️ 스크린샷

-   X

## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

#307(해당 이슈는 Close하지 않고 계속 작업 진행 예정입니다.)
