### PR TITLE
[fix/#335] 상세페이지 하단 여백 제거

### DIFF
--- a/app/(auth)/login/index.tsx
+++ b/app/(auth)/login/index.tsx
@@ -14,6 +14,7 @@ import { SIGNUP_ROUTE, VERIFY_EMAIL_ROUTE } from '@/src/shared/constants/route';
 import { getAxiosErrorCode } from '@/src/shared/utils/getAxiosErrorCode';
 import { initializeStomp } from '@/src/store/useStompStore';
 import { Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { SafeAreaWithNoNavBar } from '@/src/styles/GlobalStyles';
 
 const index = () => {
   const router = useRouter();
@@ -55,7 +56,7 @@ const index = () => {
   };
 
   return (
-    <SafeArea>
+    <SafeAreaWithNoNavBar>
       <DetailHeader title={'Continue with email'} />
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
         <Container>
@@ -81,15 +82,11 @@ const index = () => {
           </BottomButtonWrapper>
         </Container>
       </TouchableWithoutFeedback>
-    </SafeArea>
+    </SafeAreaWithNoNavBar>
   );
 };
 
 export default index;
-
-const SafeArea = styled.SafeAreaView`
-  flex: 1;
-`;
 
 const Container = styled.View`
   display: flex;

--- a/app/(auth)/signup/done/index.tsx
+++ b/app/(auth)/signup/done/index.tsx
@@ -4,9 +4,7 @@ import { StatusBar } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { textStyle } from '@/src/styles/theme';
-
-// TODO 이미지 상하단 노치까지 확대
-// TODO _layout.tsx View paddingBottom 제거
+import { SafeAreaWithNoNavBar } from '@/src/styles/GlobalStyles';
 
 const SignUpDoneScreen = () => {
   const router = useRouter();
@@ -16,7 +14,7 @@ const SignUpDoneScreen = () => {
   };
 
   return (
-    <SafeArea>
+    <SafeAreaWithNoNavBar>
       <StatusBar barStyle="light-content" />
       <Container source={require('@/assets/images/SignUpDone.png')} resizeMode="cover">
         <TitleText>Sign up Done!</TitleText>
@@ -25,15 +23,11 @@ const SignUpDoneScreen = () => {
           <ButtonText>Start</ButtonText>
         </Button>
       </Container>
-    </SafeArea>
+    </SafeAreaWithNoNavBar>
   );
 };
 
 export default SignUpDoneScreen;
-
-const SafeArea = styled.SafeAreaView`
-  flex: 1;
-`;
 
 const Container = styled.ImageBackground`
   flex: 1;

--- a/app/(auth)/signup/index.tsx
+++ b/app/(auth)/signup/index.tsx
@@ -9,6 +9,7 @@ import { useEmailSignUpForm } from '@/src/features/auth/hooks/useEmailSignUpForm
 import { useVerifyEmail } from '@/src/features/auth/hooks/useVerifyEmail';
 import CustomButton from '@/src/shared/components/CustomButton';
 import { SIGNUP_DONE_ROUTE } from '@/src/shared/constants/route';
+import { SafeAreaWithNoNavBar } from '@/src/styles/GlobalStyles';
 import { useRouter } from 'expo-router';
 import React from 'react';
 import { FormProvider } from 'react-hook-form';
@@ -47,7 +48,7 @@ const index = () => {
   };
 
   return (
-    <SafeArea>
+    <SafeAreaWithNoNavBar>
       <StatusBar barStyle="light-content" />
       <DetailHeader title="Create your account" onButtonPress={() => router.back()} />
       <Container>
@@ -76,15 +77,11 @@ const index = () => {
         onPress={() => handleEmailSignUp()}
         isLoading={isEmailSignUpLoading}
       />
-    </SafeArea>
+    </SafeAreaWithNoNavBar>
   );
 };
 
 export default index;
-
-const SafeArea = styled.SafeAreaView`
-  flex: 1;
-`;
 
 const Container = styled.View`
   flex: 1;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -15,3 +15,13 @@ export const Safe = styled(SafeAreaView)`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.primary.black};
 `;
+
+/**
+ * 내비게이션 바가 없는 페이지에서 사용하는 SafeAreaView입니다.
+ * 내비게이션 바가 없는 페이지에서는 하단 패딩이 필요 없으므로, paddingBottom을 제거한 스타일입니다.
+ */
+export const SafeAreaWithNoNavBar = styled.SafeAreaView`
+  flex: 1;
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.primary.black};
+`;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components/native';
-import { SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 /* --------------- Global Styles ---------------
  * 자주 사용하는 Styled Component를 한번에 관리하는 파일입니다.
@@ -18,10 +18,10 @@ export const Safe = styled(SafeAreaView)`
 
 /**
  * 내비게이션 바가 없는 페이지에서 사용하는 SafeAreaView입니다.
- * 내비게이션 바가 없는 페이지에서는 하단 패딩이 필요 없으므로, paddingBottom을 제거한 스타일입니다.
  */
-export const SafeAreaWithNoNavBar = styled.SafeAreaView`
+export const SafeAreaWithNoNavBar = styled(SafeAreaView).attrs({
+  edges: ['bottom'],
+})`
   flex: 1;
-  height: 100%;
   background-color: ${({ theme }) => theme.colors.primary.black};
 `;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components/native';
-import { SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 /* --------------- Global Styles ---------------
  * 자주 사용하는 Styled Component를 한번에 관리하는 파일입니다.
@@ -20,8 +20,9 @@ export const Safe = styled(SafeAreaView)`
  * 내비게이션 바가 없는 페이지에서 사용하는 SafeAreaView입니다.
  * 내비게이션 바가 없는 페이지에서는 하단 패딩이 필요 없으므로, paddingBottom을 제거한 스타일입니다.
  */
-export const SafeAreaWithNoNavBar = styled.SafeAreaView`
+export const SafeAreaWithNoNavBar = styled(SafeAreaView).attrs({
+  edges: ['bottom'], // bottom inset 제외
+})`
   flex: 1;
-  height: 100%;
   background-color: ${({ theme }) => theme.colors.primary.black};
 `;


### PR DESCRIPTION
<!-- @format -->

## 📌 작업 개요

-   상세페이지(내비게이션 바가 없는 페이지)의 하단 여백을 제거했습니다.

## 🔍 작업 상세 내용

**1. `GlobalStyles.ts`에 `SafeAreaWithNoNavBar` 스타일 컴포넌트를 구현했습니다.**

```tsx
export const SafeAreaWithNoNavBar = styled(SafeAreaView).attrs({
  edges: ['bottom'],
})`
  flex: 1;
  background-color: ${({ theme }) => theme.colors.primary.black};
`;
```
하단에 내비게이션 바가 없는 페이지에서 사용할 수 있는 `SafeAreaWithNoNavBar` 스타일 컴포넌트를 구현했습니다.
react-native-safe-area-context SafeAreaView를 활용해, inset에 추가되는 padding에도 배경색과 동일한 색상이 적용됩니다.
`SafeAreaWithNoNavBar`를 페이지 컴포넌트 최상단에 추가하면 기존 상세페이지에서 발생하던 하단의 흰색 패딩을 배경색과 동일한 색상으로 변경할 수 있습니다.

**2. Auth 도메인 내 상세페이지에 `SafeAreaWithNoNavBar`를 적용했습니다.**

이메일 로그인 페이지(app/auth/login), 회원가입 페이지(app/auth/sign-up), 회원가입 완료 페이지(app/auth/sign-up/done)에 `SafeAreaWithNoNavBar`를 적용했습니다.
나머지 페이지들은 확인 후 추후에 적용할 예정입니다.

## 🏞️ 스크린샷

<img width="200" height="1278" alt="스크린샷, 2026-02-26 오후 6 11 01" src="https://github.com/user-attachments/assets/32af6f6d-13f0-4d30-bc4b-46b6720e67c4" />


## ✅ 체크리스트

-   [ ] 빌드가 실패 없이 완료되었나요?
-   [ ] iOS와 Android에서 주요 기능이 모두 정상적으로 작동하나요?
-   [ ] 스타일이 다양한 화면 크기에서 문제가 없나요?
-   [ ] 불필요한 console.log, 주석을 제거했나요?
-   [ ] 타입 오류 및 ESLint 경고를 모두 제거했나요?

## 🔗 관련 이슈

Closes #335 
